### PR TITLE
Disable validation pipeline on the main branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ jobs:
   validate_commit:
     name: Validate Code and Publish Coverage
     runs-on: ubuntu-latest
+    if: ${{ github.ref != 'refs/heads/main' }}
     permissions:
       id-token: write      # required for dependabot PRs
       pull-requests: write # required for dependabot PRs


### PR DESCRIPTION
This change prevents the validation workflow from running after a merge.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.