### PR TITLE
Restore the test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+/integration-tests/.terraform/
+/integration-tests/terraform.tfstate
+/integration-tests/terraform.tfstate.backup
+/integration-tests/.terraform.lock.hcl

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,64 @@
+# Setting up the test environment
+
+## How to start dependencies
+The default test environment for the boxer requires Docker and Docker Compose.
+To launch the test environment, run the following command:
+
+```shell
+$ docker-compose up -d
+```
+
+## How to setup boxer for testing
+To set up the boxer entities, you can do the following steps:
+
+### Add a custom policy
+
+Create a policy
+```shell
+$ curl -X POST 'http://localhost:8888/policy/test-policy' \
+--header 'Content-Type: text/plain' \
+--data '// Only the owner can access any resource tagged "private"
+forbid ( principal, action, resource )
+when { resource.tags.contains("private") }    // assumes that resource has "tags"
+unless { resource in principal.account };     // assumes that principal has "account"'
+```
+
+Validate that the policy is created
+```shell
+curl -X GET 'http://localhost:8888/policy/test-policy'
+```
+
+### Register an identity
+
+Create an identity
+```shell
+curl -X POST 'http://localhost:8888/identity/provider/test_user'
+```
+
+Attach a created policy to a user
+```shell
+curl -X POST 'http://localhost:8888/attachment/provider/test_user/test-policy'
+```
+Validate that an identity is created and a policy is attached
+```shell
+curl -X GET 'http://localhost:8888/attachment/provider/test_user'
+```
+
+## Validate the setup
+
+### Getting the external token
+
+```shell
+$ export EXTERNAL_TOKEN=$(curl \
+  -d "client_id=test_client" \
+  -d "client_secret=test_client_secret" \
+  -d "username=test_user" \
+  -d "password=test_user_password" \
+  -d "grant_type=password" \
+  "http://localhost:8080/realms/master/protocol/openid-connect/token" | jq -r '.access_token')
+```
+
+### Getting the boxer token
+```shell
+$ curl -X GET 'http://localhost:8888/token/provider' --header "Authorization: Bearer $EXTERNAL_TOKEN"
+```

--- a/integration-tests/keycloak.tf
+++ b/integration-tests/keycloak.tf
@@ -38,3 +38,16 @@ resource "keycloak_openid_client" "test_client" {
   enabled                      = true
   direct_access_grants_enabled = true
 }
+
+resource "keycloak_openid_client_default_scopes" "client_default_scopes" {
+  realm_id  = data.keycloak_realm.master.id
+  client_id = keycloak_openid_client.test_client.id
+
+  default_scopes = [
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "microprofile-jwt",
+  ]
+}

--- a/src/http/urls.rs
+++ b/src/http/urls.rs
@@ -109,7 +109,7 @@ pub async fn post_policy_attachment(
     data: Data<Arc<PolicyAttachmentRepository>>,
 ) -> Result<HttpResponse> {
     let (identity_provider, id, policy_id) = params.into_inner();
-    let eid = ExternalIdentity::new(id, identity_provider);
+    let eid = ExternalIdentity::new(identity_provider, id);
     let attachment = PolicyAttachment::single(policy_id);
     data.upsert(eid, attachment).await.map_err(|e| {
         error!("Error: {:?}", e);
@@ -119,13 +119,13 @@ pub async fn post_policy_attachment(
 }
 
 #[utoipa::path(responses((status = OK)))]
-#[post("/attachment/{identity_provider}/{id}")]
+#[get("/attachment/{identity_provider}/{id}")]
 pub async fn get_policy_attachment(
     params: Path<(String, String)>,
     data: Data<Arc<PolicyAttachmentRepository>>,
 ) -> Result<impl Responder> {
     let (identity_provider, id) = params.into_inner();
-    let eid = ExternalIdentity::new(id, identity_provider);
+    let eid = ExternalIdentity::new(identity_provider, id);
     let result = data.get(eid).await.map_err(|e| {
         error!("Error: {:?}", e);
         ErrorInternalServerError("Failed to upsert policy")

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use utoipa_actix_web::AppExt;
 async fn main() -> Result<()> {
     std::env::set_var("RUST_LOG", "debug");
     env_logger::init();
-    let addr = ("127.0.0.1", 8080);
+    let addr = ("127.0.0.1", 8888);
     let validator_provider = Arc::new(identity_validator_provider::new());
     let cm = Arc::clone(&validator_provider);
     let secret = Arc::new(cm.get_signing_key());

--- a/src/services/configuration_manager.rs
+++ b/src/services/configuration_manager.rs
@@ -26,9 +26,9 @@ where
         let provider = ExternalIdentityProvider::from("provider".to_string());
         let settings = OidcExternalIdentityProviderSettings {
             user_id_claim: "upn".to_string(),
-            discovery_url: "https://sts.windows.net/tenantid/".to_string(),
-            issuers: vec!["https://sts.windows.net/tenantid/".to_string()],
-            audiences: vec!["https://management.core.windows.net/".to_string()],
+            discovery_url: "http://localhost:8080/realms/master/".to_string(),
+            issuers: vec!["http://localhost:8080/realms/master".to_string()],
+            audiences: vec!["account".to_string()],
         };
         let result = self.put(provider.clone(), settings).await;
         match result {

--- a/src/services/repositories/in_memory.rs
+++ b/src/services/repositories/in_memory.rs
@@ -63,7 +63,7 @@ impl UpsertRepository<PolicyAttachment, ExternalIdentity> for RwLock<HashMap<Ext
         let read_guard = self.read().await;
         match (*read_guard).get(&key) {
             Some(entity) => Ok(entity.clone()),
-            None => bail!("Entity not found"),
+            None => bail!("Entity {:?} not found", key),
         }
     }
 


### PR DESCRIPTION
This PR includes the following changes:
- The default API port changed to 8888
- The in memory repository was set up to work with keycloak
- Fixed incorrect parameters in URLS
- Fixed keycloak setup
- Added quickstart.md

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.