### PR TITLE
Extract kubeconfig from kind and ignore the default kubeconfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "test-context",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ config = "0.15.11"
 kube = { version = "1.1.0", features = ["config", "client", "runtime", "derive"] }
 k8s-openapi = { version = "0.25.0", features = ["latest"] }
 uuid = {  version = "1.17.0", features = ["v4"] }
+serde_yaml = "0.9.34+deprecated"
 
 [dev-dependencies]
 test-context = "0.4.1"

--- a/src/services/backends/kubernetes/identity_repository.rs
+++ b/src/services/backends/kubernetes/identity_repository.rs
@@ -34,6 +34,7 @@ pub struct RepositoryConfig {
     pub namespace: String,
     pub label_selector_key: String,
     pub label_selector_value: String,
+    pub kubeconfig: kube::Config
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -59,7 +60,7 @@ struct KubernetesIdentityRepository {
 impl KubernetesIdentityRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
     async fn start(config: RepositoryConfig) -> Result<Self> {
-        let client = Client::try_default().await?;
+        let client = Client::try_from(config.kubeconfig)?;
         let api: Api<IdentitiesConfigMap> = Api::namespaced(client.clone(), config.namespace.as_str());
         let watcher_config = Config {
             label_selector: Some(format!("{}={}", config.label_selector_key, config.label_selector_value)),

--- a/src/services/backends/kubernetes/identity_repository/tests.rs
+++ b/src/services/backends/kubernetes/identity_repository/tests.rs
@@ -3,8 +3,11 @@ use k8s_openapi::api::core::v1::Namespace;
 use maplit::btreemap;
 use serde_json::json;
 use std::println as info;
+use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
+use kube::config::Kubeconfig;
+use kube::Config;
 use test_context::{test_context, AsyncTestContext};
 use tokio::time::{sleep, timeout};
 use uuid::Uuid;
@@ -20,9 +23,20 @@ struct KubernetesIdentityRepositoryTest {
 static LABEL_SELECTOR_KEY: &str = "repository.boxer.io/type";
 const LABEL_SELECTOR_VALUE: &str = "identity-provider";
 
+async fn get_kubeconfig() -> Result<Config> {
+    let output = Command::new("kind").args(&["get", "kubeconfig", "--name", "kind"]).output()?;
+    let kubeconfig_string = String::from_utf8(output.stdout)?;
+    let kubeconfig: Kubeconfig = serde_yaml::from_str(&kubeconfig_string)?;
+    let config = Config::from_custom_kubeconfig(kubeconfig, &Default::default()).await?;
+    println!("{}", kubeconfig_string);
+    Ok(config)
+}
+
 impl AsyncTestContext for KubernetesIdentityRepositoryTest {
     async fn setup() -> KubernetesIdentityRepositoryTest {
-        let client = Client::try_default().await.expect("Failed to create Kubernetes client");
+        let config = get_kubeconfig().await.expect("Failed to get kubeconfig");
+
+        let client = Client::try_from(config.clone()).expect("Failed to create Kubernetes client");
 
         let namespace = Uuid::new_v4().to_string();
         info!("Using namespace: {}", namespace);
@@ -71,6 +85,7 @@ impl AsyncTestContext for KubernetesIdentityRepositoryTest {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),
+            kubeconfig: config,
         };
         let repository = KubernetesIdentityRepository::start(config)
             .await


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

Implemented:
- Awesome new feature
- And another awesome new feature

Additional changes:
- Refactored `AwesomeClass`
- Removed deprecated `AnotherClass` and `get_awesomeness` from `AwesomeClass`

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.