### PR TITLE
Rename the `KubernetesRepository` class to `KubernetesResourceManager`

### DIFF
--- a/src/services/backends/kubernetes.rs
+++ b/src/services/backends/kubernetes.rs
@@ -5,7 +5,7 @@ mod principal_repository;
 mod schema_repository;
 
 use crate::services::backends::base::{Backend, BackendConfiguration};
-use crate::services::backends::kubernetes::common::RepositoryConfig;
+use crate::services::backends::kubernetes::common::ResourceManagerConfig;
 use crate::services::backends::kubernetes::identity_repository::KubernetesIdentityRepository;
 use crate::services::backends::kubernetes::principal_association_repository::KubernetesPrincipalAssociationRepository;
 use crate::services::backends::kubernetes::principal_repository::KubernetesPrincipalRepository;
@@ -94,7 +94,7 @@ impl BackendConfiguration for KubernetesBackend {
             }
         };
 
-        let repository_config = RepositoryConfig {
+        let repository_config = ResourceManagerConfig {
             namespace: settings.namespace.clone(),
             label_selector_key: settings.label_selector_key.clone(),
             label_selector_value: settings.label_selector_value.clone(),

--- a/src/services/backends/kubernetes.rs
+++ b/src/services/backends/kubernetes.rs
@@ -5,7 +5,7 @@ mod principal_repository;
 mod schema_repository;
 
 use crate::services::backends::base::{Backend, BackendConfiguration};
-use crate::services::backends::kubernetes::common::ResourceManagerConfig;
+use crate::services::backends::kubernetes::common::KubernetesResourceManagerConfig;
 use crate::services::backends::kubernetes::identity_repository::KubernetesIdentityRepository;
 use crate::services::backends::kubernetes::principal_association_repository::KubernetesPrincipalAssociationRepository;
 use crate::services::backends::kubernetes::principal_repository::KubernetesPrincipalRepository;
@@ -94,7 +94,7 @@ impl BackendConfiguration for KubernetesBackend {
             }
         };
 
-        let repository_config = ResourceManagerConfig {
+        let repository_config = KubernetesResourceManagerConfig {
             namespace: settings.namespace.clone(),
             label_selector_key: settings.label_selector_key.clone(),
             label_selector_value: settings.label_selector_value.clone(),

--- a/src/services/backends/kubernetes/common.rs
+++ b/src/services/backends/kubernetes/common.rs
@@ -19,14 +19,14 @@ use std::sync::Arc;
 
 /// Configuration for the Kubernetes repository.
 #[derive(Clone)]
-pub struct ResourceManagerConfig {
+pub struct KubernetesResourceManagerConfig {
     pub namespace: String,
     pub label_selector_key: String,
     pub label_selector_value: String,
     pub kubeconfig: kube::Config,
 }
 
-pub struct ResourceManager<StoredObject>
+pub struct KubernetesResourceManager<StoredObject>
 where
     StoredObject: Resource + 'static,
     StoredObject::DynamicType: Hash + Eq,
@@ -44,13 +44,13 @@ where
     fn handle_update(&self, result: Result<S, watcher::Error>) -> Ready<()>;
 }
 
-impl<S> ResourceManager<S>
+impl<S> KubernetesResourceManager<S>
 where
     S: Resource<Scope = NamespaceResourceScope> + Clone + Debug + Serialize + DeserializeOwned + Send + Sync,
     S::DynamicType: Hash + Eq + Clone + Default,
 {
     pub fn new(reader: Store<S>, handle: tokio::task::JoinHandle<()>, api: Api<S>, namespace: String) -> Self {
-        ResourceManager {
+        KubernetesResourceManager {
             reader,
             handle,
             api,
@@ -110,7 +110,7 @@ where
     }
 
     pub async fn start(
-        config: ResourceManagerConfig,
+        config: KubernetesResourceManagerConfig,
         update_handler: Arc<dyn ResourceUpdateHandler<S>>,
     ) -> anyhow::Result<Self> {
         let client = Client::try_from(config.kubeconfig)?;
@@ -130,6 +130,6 @@ where
         let handle = tokio::spawn(reflector);
         reader.wait_until_ready().await?;
 
-        Ok(ResourceManager::new(reader, handle, api, config.namespace))
+        Ok(KubernetesResourceManager::new(reader, handle, api, config.namespace))
     }
 }

--- a/src/services/backends/kubernetes/common.rs
+++ b/src/services/backends/kubernetes/common.rs
@@ -19,14 +19,14 @@ use std::sync::Arc;
 
 /// Configuration for the Kubernetes repository.
 #[derive(Clone)]
-pub struct RepositoryConfig {
+pub struct ResourceManagerConfig {
     pub namespace: String,
     pub label_selector_key: String,
     pub label_selector_value: String,
     pub kubeconfig: kube::Config,
 }
 
-pub struct KubernetesRepository<StoredObject>
+pub struct ResourceManager<StoredObject>
 where
     StoredObject: Resource + 'static,
     StoredObject::DynamicType: Hash + Eq,
@@ -44,13 +44,13 @@ where
     fn handle_update(&self, result: Result<S, watcher::Error>) -> Ready<()>;
 }
 
-impl<S> KubernetesRepository<S>
+impl<S> ResourceManager<S>
 where
     S: Resource<Scope = NamespaceResourceScope> + Clone + Debug + Serialize + DeserializeOwned + Send + Sync,
     S::DynamicType: Hash + Eq + Clone + Default,
 {
     pub fn new(reader: Store<S>, handle: tokio::task::JoinHandle<()>, api: Api<S>, namespace: String) -> Self {
-        KubernetesRepository {
+        ResourceManager {
             reader,
             handle,
             api,
@@ -110,7 +110,7 @@ where
     }
 
     pub async fn start(
-        config: RepositoryConfig,
+        config: ResourceManagerConfig,
         update_handler: Arc<dyn ResourceUpdateHandler<S>>,
     ) -> anyhow::Result<Self> {
         let client = Client::try_from(config.kubeconfig)?;
@@ -130,6 +130,6 @@ where
         let handle = tokio::spawn(reflector);
         reader.wait_until_ready().await?;
 
-        Ok(KubernetesRepository::new(reader, handle, api, config.namespace))
+        Ok(ResourceManager::new(reader, handle, api, config.namespace))
     }
 }

--- a/src/services/backends/kubernetes/identity_repository.rs
+++ b/src/services/backends/kubernetes/identity_repository.rs
@@ -1,5 +1,7 @@
 use crate::models::api::external::identity::ExternalIdentity;
-use crate::services::backends::kubernetes::common::{KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{
+    KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler,
+};
 use crate::services::base::upsert_repository::UpsertRepository;
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;

--- a/src/services/backends/kubernetes/identity_repository.rs
+++ b/src/services/backends/kubernetes/identity_repository.rs
@@ -1,5 +1,5 @@
 use crate::models::api::external::identity::ExternalIdentity;
-use crate::services::backends::kubernetes::common::{ResourceManager, ResourceManagerConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler};
 use crate::services::base::upsert_repository::UpsertRepository;
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
@@ -41,13 +41,13 @@ struct IdentitiesConfigMap {
 }
 
 pub struct KubernetesIdentityRepository {
-    resource_manager: ResourceManager<IdentitiesConfigMap>,
+    resource_manager: KubernetesResourceManager<IdentitiesConfigMap>,
 }
 
 impl KubernetesIdentityRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
-    pub async fn start(config: ResourceManagerConfig) -> Result<Self> {
-        let resource_manager = ResourceManager::start(config, Arc::new(UpdateHandler)).await?;
+    pub async fn start(config: KubernetesResourceManagerConfig) -> Result<Self> {
+        let resource_manager = KubernetesResourceManager::start(config, Arc::new(UpdateHandler)).await?;
         Ok(KubernetesIdentityRepository { resource_manager })
     }
 

--- a/src/services/backends/kubernetes/identity_repository.rs
+++ b/src/services/backends/kubernetes/identity_repository.rs
@@ -1,5 +1,5 @@
 use crate::models::api::external::identity::ExternalIdentity;
-use crate::services::backends::kubernetes::common::{KubernetesRepository, RepositoryConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{ResourceManager, ResourceManagerConfig, ResourceUpdateHandler};
 use crate::services::base::upsert_repository::UpsertRepository;
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
@@ -41,23 +41,23 @@ struct IdentitiesConfigMap {
 }
 
 pub struct KubernetesIdentityRepository {
-    repository: KubernetesRepository<IdentitiesConfigMap>,
+    resource_manager: ResourceManager<IdentitiesConfigMap>,
 }
 
 impl KubernetesIdentityRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
-    pub async fn start(config: RepositoryConfig) -> Result<Self> {
-        let repository = KubernetesRepository::start(config, Arc::new(UpdateHandler)).await?;
-        Ok(KubernetesIdentityRepository { repository })
+    pub async fn start(config: ResourceManagerConfig) -> Result<Self> {
+        let resource_manager = ResourceManager::start(config, Arc::new(UpdateHandler)).await?;
+        Ok(KubernetesIdentityRepository { resource_manager })
     }
 
     async fn get_identities(&self, provider: &str) -> Result<Arc<IdentitiesConfigMap>> {
-        let or = ObjectRef::new(provider).within(self.repository.namespace().as_str());
-        self.repository.get(or).map_err(|e| {
+        let or = ObjectRef::new(provider).within(self.resource_manager.namespace().as_str());
+        self.resource_manager.get(or).map_err(|e| {
             anyhow!(
                 "Identity provider \"{}\" not found in namespace: {:?}",
                 provider,
-                self.repository.namespace()
+                self.resource_manager.namespace()
             )
             .context(e)
         })
@@ -86,7 +86,7 @@ impl KubernetesIdentityRepository {
             data: updated_data,
         };
         updated_configmap.metadata.resource_version = None;
-        self.repository.replace(provider, updated_configmap).await
+        self.resource_manager.replace(provider, updated_configmap).await
     }
 }
 
@@ -112,7 +112,7 @@ impl ResourceUpdateHandler<IdentitiesConfigMap> for UpdateHandler {
 
 impl Drop for KubernetesIdentityRepository {
     fn drop(&mut self) {
-        if let Err(e) = self.repository.stop() {
+        if let Err(e) = self.resource_manager.stop() {
             warn!("Failed to stop KubernetesIdentityRepository: {}", e);
         }
     }

--- a/src/services/backends/kubernetes/identity_repository/tests.rs
+++ b/src/services/backends/kubernetes/identity_repository/tests.rs
@@ -73,7 +73,7 @@ impl AsyncTestContext for KubernetesIdentityRepositoryTest {
                 .expect("Failed to create ConfigMap");
         }
 
-        let config = ResourceManagerConfig {
+        let config = KubernetesResourceManagerConfig {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),

--- a/src/services/backends/kubernetes/identity_repository/tests.rs
+++ b/src/services/backends/kubernetes/identity_repository/tests.rs
@@ -73,7 +73,7 @@ impl AsyncTestContext for KubernetesIdentityRepositoryTest {
                 .expect("Failed to create ConfigMap");
         }
 
-        let config = RepositoryConfig {
+        let config = ResourceManagerConfig {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),

--- a/src/services/backends/kubernetes/principal_association_repository.rs
+++ b/src/services/backends/kubernetes/principal_association_repository.rs
@@ -12,7 +12,9 @@ use std::{println as warn, println as debug};
 
 // Other imports
 use crate::models::api::external::identity::ExternalIdentity;
-use crate::services::backends::kubernetes::common::{KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{
+    KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler,
+};
 use crate::services::base::upsert_repository::{PrincipalIdentity, UpsertRepository};
 use anyhow::anyhow;
 use async_trait::async_trait;

--- a/src/services/backends/kubernetes/principal_association_repository.rs
+++ b/src/services/backends/kubernetes/principal_association_repository.rs
@@ -12,7 +12,7 @@ use std::{println as warn, println as debug};
 
 // Other imports
 use crate::models::api::external::identity::ExternalIdentity;
-use crate::services::backends::kubernetes::common::{ResourceManager, ResourceManagerConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler};
 use crate::services::base::upsert_repository::{PrincipalIdentity, UpsertRepository};
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -54,17 +54,17 @@ impl PrincipalAssociationConfigMap {
 }
 
 pub struct KubernetesPrincipalAssociationRepository {
-    resource_manger: ResourceManager<PrincipalAssociationConfigMap>,
+    resource_manger: KubernetesResourceManager<PrincipalAssociationConfigMap>,
     label_selector_key: String,
     label_selector_value: String,
 }
 
 impl KubernetesPrincipalAssociationRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
-    pub async fn start(config: ResourceManagerConfig) -> anyhow::Result<Self> {
+    pub async fn start(config: KubernetesResourceManagerConfig) -> anyhow::Result<Self> {
         let label_selector_key = config.label_selector_key.clone();
         let label_selector_value = config.label_selector_value.clone();
-        let resource_manager = ResourceManager::start(config, Arc::new(UpdateHandler)).await?;
+        let resource_manager = KubernetesResourceManager::start(config, Arc::new(UpdateHandler)).await?;
         Ok(KubernetesPrincipalAssociationRepository {
             resource_manger: resource_manager,
             label_selector_key,

--- a/src/services/backends/kubernetes/principal_association_repository.rs
+++ b/src/services/backends/kubernetes/principal_association_repository.rs
@@ -12,7 +12,7 @@ use std::{println as warn, println as debug};
 
 // Other imports
 use crate::models::api::external::identity::ExternalIdentity;
-use crate::services::backends::kubernetes::common::{KubernetesRepository, RepositoryConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{ResourceManager, ResourceManagerConfig, ResourceUpdateHandler};
 use crate::services::base::upsert_repository::{PrincipalIdentity, UpsertRepository};
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -54,19 +54,19 @@ impl PrincipalAssociationConfigMap {
 }
 
 pub struct KubernetesPrincipalAssociationRepository {
-    repository: KubernetesRepository<PrincipalAssociationConfigMap>,
+    resource_manger: ResourceManager<PrincipalAssociationConfigMap>,
     label_selector_key: String,
     label_selector_value: String,
 }
 
 impl KubernetesPrincipalAssociationRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
-    pub async fn start(config: RepositoryConfig) -> anyhow::Result<Self> {
+    pub async fn start(config: ResourceManagerConfig) -> anyhow::Result<Self> {
         let label_selector_key = config.label_selector_key.clone();
         let label_selector_value = config.label_selector_value.clone();
-        let repository = KubernetesRepository::start(config, Arc::new(UpdateHandler)).await?;
+        let resource_manager = ResourceManager::start(config, Arc::new(UpdateHandler)).await?;
         Ok(KubernetesPrincipalAssociationRepository {
-            repository,
+            resource_manger: resource_manager,
             label_selector_key,
             label_selector_value,
         })
@@ -74,8 +74,8 @@ impl KubernetesPrincipalAssociationRepository {
 
     async fn get_entities(&self, key: ExternalIdentity) -> anyhow::Result<Arc<PrincipalAssociationConfigMap>> {
         let name = format!("principals-{}", key.identity_provider);
-        let or = ObjectRef::new(&name).within(self.repository.namespace().as_str());
-        self.repository.get(or)
+        let or = ObjectRef::new(&name).within(self.resource_manger.namespace().as_str());
+        self.resource_manger.get(or)
     }
 
     async fn overwrite(
@@ -87,7 +87,7 @@ impl KubernetesPrincipalAssociationRepository {
         let updated_configmap = PrincipalAssociationConfigMap {
             metadata: ObjectMeta {
                 name: Some(name.clone()),
-                namespace: Some(self.repository.namespace().clone()),
+                namespace: Some(self.resource_manger.namespace().clone()),
                 labels: Some(btreemap! {
                     self.label_selector_key.clone() => self.label_selector_value.clone()
                 }),
@@ -95,7 +95,7 @@ impl KubernetesPrincipalAssociationRepository {
             },
             data: updated_data,
         };
-        self.repository
+        self.resource_manger
             .replace(&name, updated_configmap)
             .await
             .map_err(|e| anyhow!("Failed to update ConfigMap: {}", e))
@@ -104,7 +104,7 @@ impl KubernetesPrincipalAssociationRepository {
 
 impl Drop for KubernetesPrincipalAssociationRepository {
     fn drop(&mut self) {
-        if let Err(e) = self.repository.stop() {
+        if let Err(e) = self.resource_manger.stop() {
             warn!("Failed to stop KubernetesPrincipalAssociationRepository: {}", e);
         }
     }

--- a/src/services/backends/kubernetes/principal_association_repository/tests.rs
+++ b/src/services/backends/kubernetes/principal_association_repository/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::services::backends::kubernetes::common::RepositoryConfig;
+use crate::services::backends::kubernetes::common::ResourceManagerConfig;
 use crate::services::base::upsert_repository::UpsertRepository;
 use k8s_openapi::api::core::v1::{ConfigMap, Namespace};
 use kube::api::PostParams;
@@ -47,7 +47,7 @@ impl AsyncTestContext for KubernetesPrincipalAssociationRepositoryTest {
         let raw_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
         let data_api: Api<PrincipalAssociationConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
 
-        let config = RepositoryConfig {
+        let config = ResourceManagerConfig {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),

--- a/src/services/backends/kubernetes/principal_association_repository/tests.rs
+++ b/src/services/backends/kubernetes/principal_association_repository/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::services::backends::kubernetes::common::ResourceManagerConfig;
+use crate::services::backends::kubernetes::common::KubernetesResourceManagerConfig;
 use crate::services::base::upsert_repository::UpsertRepository;
 use k8s_openapi::api::core::v1::{ConfigMap, Namespace};
 use kube::api::PostParams;
@@ -47,7 +47,7 @@ impl AsyncTestContext for KubernetesPrincipalAssociationRepositoryTest {
         let raw_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
         let data_api: Api<PrincipalAssociationConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
 
-        let config = ResourceManagerConfig {
+        let config = KubernetesResourceManagerConfig {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),

--- a/src/services/backends/kubernetes/principal_repository.rs
+++ b/src/services/backends/kubernetes/principal_repository.rs
@@ -16,7 +16,7 @@ use std::{println as warn, println as debug};
 
 // Other imports
 use crate::models::principal::Principal;
-use crate::services::backends::kubernetes::common::{KubernetesRepository, RepositoryConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{ResourceManager, ResourceManagerConfig, ResourceUpdateHandler};
 use crate::services::base::upsert_repository::{PrincipalIdentity, UpsertRepository};
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
@@ -64,34 +64,34 @@ impl PrincipalConfigMap {
 }
 
 pub struct KubernetesPrincipalRepository {
-    repository: KubernetesRepository<PrincipalConfigMap>,
+    resource_manager: ResourceManager<PrincipalConfigMap>,
     label_selector_key: String,
     label_selector_value: String,
 }
 
 impl KubernetesPrincipalRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
-    pub async fn start(config: RepositoryConfig) -> anyhow::Result<Self> {
+    pub async fn start(config: ResourceManagerConfig) -> anyhow::Result<Self> {
         let label_selector_key = config.label_selector_key.clone();
         let label_selector_value = config.label_selector_value.clone();
-        let repository = KubernetesRepository::start(config, Arc::new(UpdateHandler)).await?;
+        let resource_manager = ResourceManager::start(config, Arc::new(UpdateHandler)).await?;
         Ok(KubernetesPrincipalRepository {
-            repository,
+            resource_manager,
             label_selector_key,
             label_selector_value,
         })
     }
 
     async fn get_entities(&self, schema: &str) -> anyhow::Result<Arc<PrincipalConfigMap>> {
-        let or = ObjectRef::new(schema).within(self.repository.namespace().as_str());
-        self.repository.get(or)
+        let or = ObjectRef::new(schema).within(self.resource_manager.namespace().as_str());
+        self.resource_manager.get(or)
     }
 
     async fn overwrite(&self, key: PrincipalIdentity, updated_data: PrincipalData) -> Result<(), anyhow::Error> {
         let updated_configmap = PrincipalConfigMap {
             metadata: ObjectMeta {
                 name: Some(key.schema_id().clone()),
-                namespace: Some(self.repository.namespace().clone()),
+                namespace: Some(self.resource_manager.namespace().clone()),
                 labels: Some(btreemap! {
                     self.label_selector_key.clone() => self.label_selector_value.clone()
                 }),
@@ -99,7 +99,7 @@ impl KubernetesPrincipalRepository {
             },
             data: updated_data,
         };
-        self.repository
+        self.resource_manager
             .replace(&key.schema_id(), updated_configmap)
             .await
             .map_err(|e| anyhow!("Failed to update ConfigMap: {}", e))
@@ -108,7 +108,7 @@ impl KubernetesPrincipalRepository {
 
 impl Drop for KubernetesPrincipalRepository {
     fn drop(&mut self) {
-        if let Err(e) = self.repository.stop() {
+        if let Err(e) = self.resource_manager.stop() {
             warn!("Failed to stop KubernetesPrincipalRepository: {}", e);
         }
     }

--- a/src/services/backends/kubernetes/principal_repository.rs
+++ b/src/services/backends/kubernetes/principal_repository.rs
@@ -16,7 +16,9 @@ use std::{println as warn, println as debug};
 
 // Other imports
 use crate::models::principal::Principal;
-use crate::services::backends::kubernetes::common::{KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{
+    KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler,
+};
 use crate::services::base::upsert_repository::{PrincipalIdentity, UpsertRepository};
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;

--- a/src/services/backends/kubernetes/principal_repository.rs
+++ b/src/services/backends/kubernetes/principal_repository.rs
@@ -16,7 +16,7 @@ use std::{println as warn, println as debug};
 
 // Other imports
 use crate::models::principal::Principal;
-use crate::services::backends::kubernetes::common::{ResourceManager, ResourceManagerConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler};
 use crate::services::base::upsert_repository::{PrincipalIdentity, UpsertRepository};
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
@@ -64,17 +64,17 @@ impl PrincipalConfigMap {
 }
 
 pub struct KubernetesPrincipalRepository {
-    resource_manager: ResourceManager<PrincipalConfigMap>,
+    resource_manager: KubernetesResourceManager<PrincipalConfigMap>,
     label_selector_key: String,
     label_selector_value: String,
 }
 
 impl KubernetesPrincipalRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
-    pub async fn start(config: ResourceManagerConfig) -> anyhow::Result<Self> {
+    pub async fn start(config: KubernetesResourceManagerConfig) -> anyhow::Result<Self> {
         let label_selector_key = config.label_selector_key.clone();
         let label_selector_value = config.label_selector_value.clone();
-        let resource_manager = ResourceManager::start(config, Arc::new(UpdateHandler)).await?;
+        let resource_manager = KubernetesResourceManager::start(config, Arc::new(UpdateHandler)).await?;
         Ok(KubernetesPrincipalRepository {
             resource_manager,
             label_selector_key,

--- a/src/services/backends/kubernetes/principal_repository/tests.rs
+++ b/src/services/backends/kubernetes/principal_repository/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::services::backends::kubernetes::common::ResourceManagerConfig;
+use crate::services::backends::kubernetes::common::KubernetesResourceManagerConfig;
 use crate::services::backends::kubernetes::principal_repository::test_principal::{principal, updated_principal};
 use crate::services::base::upsert_repository::UpsertRepository;
 use k8s_openapi::api::core::v1::{ConfigMap, Namespace};
@@ -48,7 +48,7 @@ impl AsyncTestContext for KubernetesPrincipalRepositoryTest {
         let raw_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
         let data_api: Api<PrincipalConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
 
-        let config = ResourceManagerConfig {
+        let config = KubernetesResourceManagerConfig {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),

--- a/src/services/backends/kubernetes/principal_repository/tests.rs
+++ b/src/services/backends/kubernetes/principal_repository/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::services::backends::kubernetes::common::RepositoryConfig;
+use crate::services::backends::kubernetes::common::ResourceManagerConfig;
 use crate::services::backends::kubernetes::principal_repository::test_principal::{principal, updated_principal};
 use crate::services::base::upsert_repository::UpsertRepository;
 use k8s_openapi::api::core::v1::{ConfigMap, Namespace};
@@ -48,7 +48,7 @@ impl AsyncTestContext for KubernetesPrincipalRepositoryTest {
         let raw_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
         let data_api: Api<PrincipalConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
 
-        let config = RepositoryConfig {
+        let config = ResourceManagerConfig {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),

--- a/src/services/backends/kubernetes/schema_repository.rs
+++ b/src/services/backends/kubernetes/schema_repository.rs
@@ -17,7 +17,7 @@ use log::{debug, warn};
 use std::{println as warn, println as debug};
 
 // Other imports
-use crate::services::backends::kubernetes::common::{KubernetesRepository, RepositoryConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{ResourceManager, ResourceManagerConfig, ResourceUpdateHandler};
 use crate::services::base::upsert_repository::UpsertRepository;
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -69,19 +69,19 @@ struct SchemaConfigMap {
 }
 
 pub struct KubernetesSchemaRepository {
-    repository: KubernetesRepository<SchemaConfigMap>,
+    resource_manger: ResourceManager<SchemaConfigMap>,
     label_selector_key: String,
     label_selector_value: String,
 }
 
 impl KubernetesSchemaRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
-    pub async fn start(config: RepositoryConfig) -> anyhow::Result<Self> {
+    pub async fn start(config: ResourceManagerConfig) -> anyhow::Result<Self> {
         let label_selector_key = config.label_selector_key.clone();
         let label_selector_value = config.label_selector_value.clone();
-        let repository = KubernetesRepository::start(config, Arc::new(UpdateHandler)).await?;
+        let resource_manger = ResourceManager::start(config, Arc::new(UpdateHandler)).await?;
         Ok(KubernetesSchemaRepository {
-            repository,
+            resource_manger,
             label_selector_key,
             label_selector_value,
         })
@@ -90,7 +90,7 @@ impl KubernetesSchemaRepository {
 
 impl Drop for KubernetesSchemaRepository {
     fn drop(&mut self) {
-        if let Err(e) = self.repository.stop() {
+        if let Err(e) = self.resource_manger.stop() {
             warn!("Failed to stop KubernetesSchemaRepository: {}", e);
         }
     }
@@ -121,8 +121,8 @@ impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
     type Error = anyhow::Error;
 
     async fn get(&self, key: String) -> Result<SchemaFragment, Self::Error> {
-        let or = ObjectRef::new(key.as_str()).within(self.repository.namespace().as_str());
-        let resource_object = self.repository.get(or).map_err(|e| anyhow!(e))?;
+        let or = ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
+        let resource_object = self.resource_manger.get(or).map_err(|e| anyhow!(e))?;
         if resource_object.data.active.contains("false") {
             return Err(anyhow!("Schema is not active"));
         }
@@ -134,7 +134,7 @@ impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
         let updated_configmap = SchemaConfigMap {
             metadata: ObjectMeta {
                 name: Some(key.clone()),
-                namespace: Some(self.repository.namespace().clone()),
+                namespace: Some(self.resource_manger.namespace().clone()),
                 labels: Some(btreemap! {
                     self.label_selector_key.clone() => self.label_selector_value.clone()
                 }),
@@ -142,26 +142,26 @@ impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
             },
             data: entity.try_into()?,
         };
-        self.repository
+        self.resource_manger
             .replace(&key, updated_configmap)
             .await
             .map_err(|e| anyhow!("Failed to update ConfigMap: {}", e))
     }
 
     async fn delete(&self, key: String) -> Result<(), Self::Error> {
-        let or = ObjectRef::new(key.as_str()).within(self.repository.namespace().as_str());
-        let mut resource_ref = self.repository.get(or).map_err(|e| anyhow!(e))?;
+        let or = ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
+        let mut resource_ref = self.resource_manger.get(or).map_err(|e| anyhow!(e))?;
         if resource_ref.data.active.contains("false") {
             return Ok(());
         }
         let resource_object = Arc::make_mut(&mut resource_ref);
         resource_object.data.active = "false".to_string();
-        self.repository.replace(&key, resource_object.clone()).await
+        self.resource_manger.replace(&key, resource_object.clone()).await
     }
 
     async fn exists(&self, key: String) -> Result<bool, Self::Error> {
-        let or: ObjectRef<SchemaConfigMap> = ObjectRef::new(key.as_str()).within(self.repository.namespace().as_str());
-        self.repository.get(or).map(|_| true).or_else(|e| {
+        let or: ObjectRef<SchemaConfigMap> = ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
+        self.resource_manger.get(or).map(|_| true).or_else(|e| {
             if e.to_string().contains("not found") {
                 Ok(false)
             } else {

--- a/src/services/backends/kubernetes/schema_repository.rs
+++ b/src/services/backends/kubernetes/schema_repository.rs
@@ -17,7 +17,7 @@ use log::{debug, warn};
 use std::{println as warn, println as debug};
 
 // Other imports
-use crate::services::backends::kubernetes::common::{ResourceManager, ResourceManagerConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler};
 use crate::services::base::upsert_repository::UpsertRepository;
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -69,17 +69,17 @@ struct SchemaConfigMap {
 }
 
 pub struct KubernetesSchemaRepository {
-    resource_manger: ResourceManager<SchemaConfigMap>,
+    resource_manger: KubernetesResourceManager<SchemaConfigMap>,
     label_selector_key: String,
     label_selector_value: String,
 }
 
 impl KubernetesSchemaRepository {
     #[allow(dead_code)] // Dead code is allowed here because this function is used in kubernetes
-    pub async fn start(config: ResourceManagerConfig) -> anyhow::Result<Self> {
+    pub async fn start(config: KubernetesResourceManagerConfig) -> anyhow::Result<Self> {
         let label_selector_key = config.label_selector_key.clone();
         let label_selector_value = config.label_selector_value.clone();
-        let resource_manger = ResourceManager::start(config, Arc::new(UpdateHandler)).await?;
+        let resource_manger = KubernetesResourceManager::start(config, Arc::new(UpdateHandler)).await?;
         Ok(KubernetesSchemaRepository {
             resource_manger,
             label_selector_key,

--- a/src/services/backends/kubernetes/schema_repository.rs
+++ b/src/services/backends/kubernetes/schema_repository.rs
@@ -160,7 +160,8 @@ impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
     }
 
     async fn exists(&self, key: String) -> Result<bool, Self::Error> {
-        let or: ObjectRef<SchemaConfigMap> = ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
+        let or: ObjectRef<SchemaConfigMap> =
+            ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
         self.resource_manger.get(or).map(|_| true).or_else(|e| {
             if e.to_string().contains("not found") {
                 Ok(false)

--- a/src/services/backends/kubernetes/schema_repository.rs
+++ b/src/services/backends/kubernetes/schema_repository.rs
@@ -17,7 +17,9 @@ use log::{debug, warn};
 use std::{println as warn, println as debug};
 
 // Other imports
-use crate::services::backends::kubernetes::common::{KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler};
+use crate::services::backends::kubernetes::common::{
+    KubernetesResourceManager, KubernetesResourceManagerConfig, ResourceUpdateHandler,
+};
 use crate::services::base::upsert_repository::UpsertRepository;
 use anyhow::anyhow;
 use async_trait::async_trait;

--- a/src/services/backends/kubernetes/schema_repository/tests.rs
+++ b/src/services/backends/kubernetes/schema_repository/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::services::backends::kubernetes::common::RepositoryConfig;
+use crate::services::backends::kubernetes::common::ResourceManagerConfig;
 use crate::services::backends::kubernetes::schema_repository::test_reduced_schema::reduced_schema;
 use crate::services::backends::kubernetes::schema_repository::test_schema::schema;
 use crate::services::base::upsert_repository::UpsertRepository;
@@ -51,7 +51,7 @@ impl AsyncTestContext for KubernetesSchemaRepositoryTest {
         let raw_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
         let data_api: Api<SchemaConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
 
-        let config = RepositoryConfig {
+        let config = ResourceManagerConfig {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),

--- a/src/services/backends/kubernetes/schema_repository/tests.rs
+++ b/src/services/backends/kubernetes/schema_repository/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::services::backends::kubernetes::common::ResourceManagerConfig;
+use crate::services::backends::kubernetes::common::KubernetesResourceManagerConfig;
 use crate::services::backends::kubernetes::schema_repository::test_reduced_schema::reduced_schema;
 use crate::services::backends::kubernetes::schema_repository::test_schema::schema;
 use crate::services::base::upsert_repository::UpsertRepository;
@@ -51,7 +51,7 @@ impl AsyncTestContext for KubernetesSchemaRepositoryTest {
         let raw_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
         let data_api: Api<SchemaConfigMap> = Api::namespaced(client.clone(), namespace.as_str());
 
-        let config = ResourceManagerConfig {
+        let config = KubernetesResourceManagerConfig {
             namespace: namespace.clone(),
             label_selector_key: LABEL_SELECTOR_KEY.to_string(),
             label_selector_value: LABEL_SELECTOR_VALUE.to_string(),


### PR DESCRIPTION
Part of #101

## Scope

Implemented:
- Use the better name for a class

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.