### PR TITLE
Add the helm chart workflow

### DIFF
--- a/.github/workflows/bild-container-image.yaml
+++ b/.github/workflows/bild-container-image.yaml
@@ -1,0 +1,67 @@
+name: Build Container Image
+run-name: Build Boxer Issuer Container Image for GHCR from ${{ github.ref }} by @${{ github.actor }}
+
+on: workflow_dispatch
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build_image:
+    name: Build Docker Image and Helm Charts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get project version
+        uses: SneaksAndData/github-actions/generate_version@v0.1.9
+        id: version
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{steps.version.outputs.version}}
+          flavor:
+            latest=false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.8.0
+        with:
+          use: true
+          platforms: linux/amd64
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6.10.0
+        with:
+          context: .
+          file: .container/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64,linux/amd64
+
+      - name: Build and Push Chart
+        uses: SneaksAndData/github-actions/build_helm_chart@v0.1.9
+        with:
+          application: ${{ github.event.repository.name }}
+          app_version: ${{ steps.meta.outputs.version }}
+          container_registry_user: ${{ github.actor }}
+          container_registry_token: ${{ secrets.GITHUB_TOKEN }}
+          container_registry_address: ghcr.io/sneaksanddata/


### PR DESCRIPTION
Add the workflow that builds and pushes the Helm Chart to GH repository.
Merging this PR is required for testing, since the WF Dispatch actions should be in `main` for testing.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.