### PR TITLE
Fix the OpenAPI generation

### DIFF
--- a/src/http/controllers/association.rs
+++ b/src/http/controllers/association.rs
@@ -19,7 +19,7 @@ struct IdentityAssociation {
 
 #[utoipa::path(context_path = "/association", responses((status = OK)))]
 #[post("/")]
-async fn post(
+async fn post_association(
     request: Json<IdentityAssociation>,
     principal_service: Data<Arc<PrincipalService>>,
 ) -> Result<HttpResponse> {
@@ -38,7 +38,10 @@ async fn post(
     )
 )]
 #[get("/identities/{identity_provider}/{id}")]
-async fn get(path: Path<(String, String)>, data: Data<Arc<PrincipalAssociationRepository>>) -> Result<impl Responder> {
+async fn get_association(
+    path: Path<(String, String)>,
+    data: Data<Arc<PrincipalAssociationRepository>>,
+) -> Result<impl Responder> {
     let external_identity = ExternalIdentity::from(path.into_inner());
     let principal_id = data.get(external_identity.clone()).await?;
     Ok(Json(IdentityAssociation {
@@ -50,5 +53,7 @@ async fn get(path: Path<(String, String)>, data: Data<Arc<PrincipalAssociationRe
 }
 
 pub fn crud() -> impl HttpServiceFactory {
-    web::scope("/association").service(post).service(get)
+    web::scope("/association")
+        .service(post_association)
+        .service(get_association)
 }

--- a/src/http/controllers/identity.rs
+++ b/src/http/controllers/identity.rs
@@ -8,7 +8,10 @@ use std::sync::Arc;
 
 #[utoipa::path(context_path = "/identity/", responses((status = OK)))]
 #[post("{identity_provider}/{id}")]
-pub async fn post(params: Path<(String, String)>, data: Data<Arc<IdentityRepository>>) -> Result<HttpResponse> {
+pub async fn post_identity(
+    params: Path<(String, String)>,
+    data: Data<Arc<IdentityRepository>>,
+) -> Result<HttpResponse> {
     let key = params.into_inner();
     let eid = ExternalIdentity::from(key.clone());
     data.upsert(key, eid).await?;
@@ -17,18 +20,27 @@ pub async fn post(params: Path<(String, String)>, data: Data<Arc<IdentityReposit
 
 #[utoipa::path(context_path = "/identity/", responses((status = OK)))]
 #[get("{identity_provider}/{id}")]
-pub async fn get(params: Path<(String, String)>, data: Data<Arc<IdentityRepository>>) -> Result<impl Responder> {
+pub async fn get_identity(
+    params: Path<(String, String)>,
+    data: Data<Arc<IdentityRepository>>,
+) -> Result<impl Responder> {
     let eid = data.get(params.into_inner()).await?;
     Ok(web::Json(eid))
 }
 
 #[utoipa::path(context_path = "/identity/", responses((status = OK)))]
 #[delete("{identity_provider}/{id}")]
-pub async fn delete(params: Path<(String, String)>, data: Data<Arc<IdentityRepository>>) -> Result<HttpResponse> {
+pub async fn delete_identity(
+    params: Path<(String, String)>,
+    data: Data<Arc<IdentityRepository>>,
+) -> Result<HttpResponse> {
     data.delete(params.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 
 pub fn crud() -> impl HttpServiceFactory {
-    web::scope("/identity").service(post).service(get).service(delete)
+    web::scope("/identity")
+        .service(post_identity)
+        .service(get_identity)
+        .service(delete_identity)
 }

--- a/src/http/controllers/principal.rs
+++ b/src/http/controllers/principal.rs
@@ -3,14 +3,14 @@ use crate::models::principal::Principal;
 use crate::services::base::upsert_repository::{PrincipalIdentity, PrincipalRepository};
 use actix_web::dev::HttpServiceFactory;
 use actix_web::web::{Data, Path};
-use actix_web::{delete, get, post, web, HttpResponse};
+use actix_web::{get, post, web, HttpResponse};
 use boxer_core::services::base::types::SchemaRepository;
 use cedar_policy::{Entity, Schema};
 use std::sync::Arc;
 
 #[utoipa::path(context_path = "/principal/", responses((status = OK)))]
 #[post("{schema}")]
-async fn post(
+async fn post_principal(
     schema_id: Path<String>,
     principal_json: String,
     schemas_repository: Data<Arc<SchemaRepository>>,
@@ -30,21 +30,13 @@ async fn post(
 
 #[utoipa::path(context_path = "/principal/", responses((status = OK)))]
 #[get("{schema}/{id}")]
-async fn get(path: Path<(String, String)>, data: Data<Arc<PrincipalRepository>>) -> Result<String> {
+async fn get_principal(path: Path<(String, String)>, data: Data<Arc<PrincipalRepository>>) -> Result<String> {
     let (schema, id) = path.into_inner();
     let principal = data.get(PrincipalIdentity::from((schema, id))).await?;
     let json = principal.get_entity().to_json_string()?;
     Ok(json)
 }
 
-#[utoipa::path(context_path = "/principal/", responses((status = OK)))]
-#[delete("{schema}/{id}")]
-async fn delete(path: Path<(String, String)>, data: Data<Arc<PrincipalRepository>>) -> Result<HttpResponse> {
-    let (schema, id) = path.into_inner();
-    data.delete(PrincipalIdentity::from((schema, id))).await?;
-    Ok(HttpResponse::Ok().finish())
-}
-
 pub fn crud() -> impl HttpServiceFactory {
-    web::scope("/principal").service(post).service(get).service(delete)
+    web::scope("/principal").service(post_principal).service(get_principal)
 }

--- a/src/http/controllers/provider.rs
+++ b/src/http/controllers/provider.rs
@@ -19,7 +19,7 @@ struct OidcIdentityProviderRegistration {
 
 #[utoipa::path(context_path = "/identity_provider/", responses((status = OK)))]
 #[post("oidc/{id}")]
-pub async fn post(
+pub async fn post_provider(
     id: Path<String>,
     registration: Json<OidcIdentityProviderRegistration>,
     data: Data<Arc<IdentityProviderRepository>>,
@@ -39,21 +39,21 @@ pub async fn post(
 
 #[utoipa::path(context_path = "/identity_provider/", responses((status = OK, body = OidcIdentityProviderRegistration)))]
 #[get("oidc/{id}")]
-pub async fn get(id: Path<String>, data: Data<Arc<IdentityProviderRepository>>) -> Result<impl Responder> {
+pub async fn get_provider(id: Path<String>, data: Data<Arc<IdentityProviderRepository>>) -> Result<impl Responder> {
     let eid = data.get(id.into_inner()).await?;
     Ok(web::Json(eid))
 }
 
 #[utoipa::path(context_path = "/identity_provider/", responses((status = OK)))]
 #[delete("oidc/{id}")]
-pub async fn delete(id: Path<String>, data: Data<Arc<IdentityProviderRepository>>) -> Result<HttpResponse> {
+pub async fn delete_provider(id: Path<String>, data: Data<Arc<IdentityProviderRepository>>) -> Result<HttpResponse> {
     data.delete(id.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 
 pub fn crud() -> impl HttpServiceFactory {
     web::scope("/identity_provider")
-        .service(post)
-        .service(get)
-        .service(delete)
+        .service(post_provider)
+        .service(get_provider)
+        .service(delete_provider)
 }

--- a/src/http/controllers/schema.rs
+++ b/src/http/controllers/schema.rs
@@ -11,7 +11,11 @@ const MAX_SCHEMA_SIZE: usize = 262_144; // max payload size is 256k
 
 #[utoipa::path(context_path = "/schema/", responses((status = OK)))]
 #[post("{id}")]
-async fn post(id: Path<String>, mut payload: Payload, data: Data<Arc<SchemaRepository>>) -> Result<HttpResponse> {
+async fn post_schema(
+    id: Path<String>,
+    mut payload: Payload,
+    data: Data<Arc<SchemaRepository>>,
+) -> Result<HttpResponse> {
     let mut body = BytesMut::new();
     while let Some(chunk) = payload.next().await {
         let chunk = chunk?;
@@ -29,7 +33,7 @@ async fn post(id: Path<String>, mut payload: Payload, data: Data<Arc<SchemaRepos
 
 #[utoipa::path(context_path = "/schema/", responses((status = OK)))]
 #[get("{id}")]
-async fn get(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Result<String> {
+async fn get_schema(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Result<String> {
     let schema = data.get(id.to_string()).await?;
     let result = schema.to_json_string()?;
     Ok(result)
@@ -37,11 +41,14 @@ async fn get(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Result<Stri
 
 #[utoipa::path(context_path = "/schema/", responses((status = OK)))]
 #[delete("{id}")]
-async fn delete(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Result<HttpResponse> {
+async fn delete_schema(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Result<HttpResponse> {
     data.delete(id.to_string()).await?;
     Ok(HttpResponse::Ok().finish())
 }
 
 pub fn crud() -> impl HttpServiceFactory {
-    web::scope("/schema").service(post).service(get).service(delete)
+    web::scope("/schema")
+        .service(post_schema)
+        .service(get_schema)
+        .service(delete_schema)
 }

--- a/src/http/openapi.rs
+++ b/src/http/openapi.rs
@@ -3,20 +3,18 @@ use utoipa::OpenApi;
 
 #[derive(OpenApi)]
 #[openapi(paths(
-    controllers::provider::post,
-    controllers::provider::get,
-    controllers::provider::delete,
-    controllers::identity::post,
-    controllers::identity::get,
-    controllers::identity::delete,
+    controllers::identity::post_identity,
+    controllers::identity::get_identity,
+    controllers::identity::delete_identity,
+    controllers::schema::post_schema,
+    controllers::schema::get_schema,
+    controllers::schema::delete_schema,
+    controllers::principal::post_principal,
+    controllers::principal::get_principal,
+    controllers::provider::post_provider,
+    controllers::provider::get_provider,
     controllers::token::token,
-    controllers::schema::post,
-    controllers::schema::get,
-    controllers::schema::delete,
-    controllers::principal::post,
-    controllers::principal::get,
-    controllers::principal::delete,
-    controllers::association::post,
-    controllers::association::get,
+    controllers::association::post_association,
+    controllers::association::get_association,
 ))]
 pub struct ApiDoc;

--- a/src/services/backends/kubernetes/principal_repository.rs
+++ b/src/services/backends/kubernetes/principal_repository.rs
@@ -19,9 +19,7 @@ use crate::services::base::upsert_repository::PrincipalIdentity;
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use boxer_core::services::backends::kubernetes::kubernetes_resource_manager::KubernetesResourceManagerConfig;
-use boxer_core::services::base::upsert_repository::{
-    CanDelete, ReadOnlyRepository, UpsertRepository, UpsertRepositoryWithDelete,
-};
+use boxer_core::services::base::upsert_repository::{ReadOnlyRepository, UpsertRepository};
 use cedar_policy::{Entities, EntityUid};
 use futures::future;
 use futures::future::Ready;
@@ -243,37 +241,3 @@ impl ReadOnlyRepository<PrincipalIdentity, Principal> for KubernetesPrincipalRep
         Ok(Principal::new(entity.clone(), key.schema_id().clone()))
     }
 }
-
-#[async_trait]
-impl CanDelete<PrincipalIdentity, Principal> for KubernetesPrincipalRepository {
-    type DeleteError = anyhow::Error;
-
-    async fn delete(&self, key: PrincipalIdentity) -> Result<(), Self::DeleteError> {
-        let entity_uid: EntityUid = (&key).try_into()?;
-        let mut resource = self
-            .get_entities(key.schema_id())
-            .await
-            .ok_or(anyhow!("Cannot find entities for schema {}", key.schema_id()))?;
-        let resource = Arc::make_mut(&mut resource);
-
-        let active_entities = resource.spec.entities.get_active_entities()?;
-
-        let to_delete = active_entities
-            .get(&entity_uid)
-            .ok_or(anyhow!("Entity with UID {} not found in active entities", entity_uid))?;
-
-        let active_entities = active_entities.clone().remove_entities(Some(entity_uid))?;
-        let inactive_entities = resource
-            .spec
-            .entities
-            .get_inactive_entities()?
-            .add_entities(Some(to_delete.clone()), None)?;
-
-        resource.spec.entities.active = serialize_entities(&active_entities)?;
-        resource.spec.entities.inactive = serialize_entities(&inactive_entities)?;
-        self.overwrite(key, resource).await?;
-        Ok(())
-    }
-}
-
-impl UpsertRepositoryWithDelete<PrincipalIdentity, Principal> for KubernetesPrincipalRepository {}

--- a/src/services/backends/kubernetes/principal_repository/tests.rs
+++ b/src/services/backends/kubernetes/principal_repository/tests.rs
@@ -109,32 +109,6 @@ async fn test_create_principal(ctx: &mut KubernetesPrincipalRepositoryTest) {
 
 #[test_context(KubernetesPrincipalRepositoryTest)]
 #[tokio::test]
-async fn test_delete_principal(ctx: &mut KubernetesPrincipalRepositoryTest) {
-    // Arrange
-    let name = "test-schema-entities";
-    let principal_id = PrincipalIdentity::new(name.to_string(), "PhotoApp::User::\"alice\"".to_string());
-    sleep(Duration::from_secs(1)).await; // Ensure the schema is created before retrieving it
-
-    ctx.repository
-        .upsert(principal_id.clone(), principal(name.to_string()))
-        .await
-        .expect("Failed to upsert principal");
-
-    // Act
-    ctx.repository
-        .delete(principal_id.clone())
-        .await
-        .expect("Failed to delete principal");
-
-    sleep(Duration::from_secs(1)).await; // Ensure the schema is created before retrieving it
-
-    // Assert
-    let principal_result = ctx.repository.get(principal_id).await;
-    assert!(principal_result.is_err(), "Principal should not exist after deletion");
-}
-
-#[test_context(KubernetesPrincipalRepositoryTest)]
-#[tokio::test]
 async fn test_update_schema(ctx: &mut KubernetesPrincipalRepositoryTest) {
     // Arrange
     let name = "test-schema-entities";

--- a/src/services/base/upsert_repository.rs
+++ b/src/services/base/upsert_repository.rs
@@ -22,13 +22,8 @@ pub type IdentityRepository = dyn UpsertRepositoryWithDelete<
     DeleteError = anyhow::Error,
 >;
 
-pub type PrincipalRepository = dyn UpsertRepositoryWithDelete<
-    PrincipalIdentity,
-    Principal,
-    Error = anyhow::Error,
-    ReadError = anyhow::Error,
-    DeleteError = anyhow::Error,
->;
+pub type PrincipalRepository =
+    dyn UpsertRepository<PrincipalIdentity, Principal, Error = anyhow::Error, ReadError = anyhow::Error>;
 
 pub type PrincipalAssociationRepository =
     dyn UpsertRepository<ExternalIdentity, PrincipalIdentity, Error = anyhow::Error, ReadError = anyhow::Error>;


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/terraform-provider-boxer/issues/7
## Scope

Implemented:
- Fixes the operationId duplicates

Additional changes:
- Adjusted API by removing the `delete` method from the `principal` controller

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.