### PR TITLE
Restore boxer-issuer tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,24 +38,26 @@ jobs:
         uses: actions-rust-lang/rustfmt@v1
 
       - name: Create k8s Kind Cluster
-        if: ${{ false }}
         uses: helm/kind-action@v1
         with:
           cluster_name: 'kind'
 
       - name: Check kind cluster
-        if: ${{ false }}
         run: |
           kubectl cluster-info
           kubectl get nodes
           kind get kubeconfig --name kind
 
+      - name: Install integration test dependencies
+        run: |
+          helm dependency build ./integration-tests/helm/integration_tests \
+          && helm install integration-tests ./integration-tests/helm/integration_tests 
+
+
       - name: Generate code coverage
-        if: ${{ false }}
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        if: ${{ false }}
         uses: romeovs/lcov-reporter-action@v0.4.0
         with:
           lcov-file: ./lcov.info

--- a/integration-tests/helm/integration_tests/.helmignore
+++ b/integration-tests/helm/integration_tests/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/integration-tests/helm/integration_tests/Chart.lock
+++ b/integration-tests/helm/integration_tests/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: boxer-crd
+  repository: oci://ghcr.io/sneaksanddata/helm
+  version: v0.0.0-5-g054dcff
+digest: sha256:0b6286cf8aaf50ae2e9e59612404ed8bcc76e13085200844c6bd66d8a18dd986
+generated: "2025-08-06T09:56:35.118945+02:00"

--- a/integration-tests/helm/integration_tests/Chart.yaml
+++ b/integration-tests/helm/integration_tests/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: integration_tests
+description: A Helm chart for the Boxer project integration tests
+type: application
+version: 0.0.0
+appVersion: "0.0.0"
+dependencies:
+  - name: boxer-crd
+    version: "v0.0.0-5-g054dcff"
+    repository: "oci://ghcr.io/sneaksanddata/helm"

--- a/integration-tests/helm/integration_tests/templates/NOTES.txt
+++ b/integration-tests/helm/integration_tests/templates/NOTES.txt
@@ -1,0 +1,4 @@
+IMPORTANT NOTE:
+This chart is designed to be used in integration tests and is not intended for production use.
+If you want to install the Boxer Issuer application, please use the Boxer Issuer chart instead.
+The boxer issuer chart can be found at: https://github.com/SneaksAndData/boxer-crd/pkgs/container/helm%2Fboxer-crd

--- a/integration-tests/helm/integration_tests/templates/_helpers.tpl
+++ b/integration-tests/helm/integration_tests/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "integration_tests.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "integration_tests.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "integration_tests.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "integration_tests.labels" -}}
+helm.sh/chart: {{ include "integration_tests.chart" . }}
+{{ include "integration_tests.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "integration_tests.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "integration_tests.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "integration_tests.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "integration_tests.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/integration-tests/helm/integration_tests/values.yaml
+++ b/integration-tests/helm/integration_tests/values.yaml
@@ -1,0 +1,1 @@
+environment: development

--- a/src/services/backends/kubernetes/principal_association_repository/tests.rs
+++ b/src/services/backends/kubernetes/principal_association_repository/tests.rs
@@ -153,7 +153,7 @@ async fn test_delete_principal(ctx: &mut KubernetesPrincipalAssociationRepositor
 #[tokio::test]
 async fn test_update_schema(ctx: &mut KubernetesPrincipalAssociationRepositoryTest) {
     // Arrange
-    let external_identity = ExternalIdentity::new("identity-provider".to_string(), "external_id".to_string());
+    let external_identity = ExternalIdentity::new("identity-provider-1".to_string(), "user1".to_string());
     let principal_identity = PrincipalIdentity::new(
         "test-schema-entities".to_string(),
         "PhotoApp::User::\"alice\"".to_string(),


### PR DESCRIPTION
Follow-up for #117

## Scope

Implemented:
- Added the `boxer-crd` installation before running tests
- Unit tests restored


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.