### PR TITLE
Add the internal token auth scheme to the provider

### DIFF
--- a/src/http/controllers/identity.rs
+++ b/src/http/controllers/identity.rs
@@ -13,6 +13,9 @@ use std::sync::Arc;
     request_body = ExternalIdentityRegistrationRequest,
     responses(
         (status = OK)
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[post("{identity_provider}/{id}")]
@@ -32,6 +35,9 @@ pub async fn post_identity(
     responses(
         (status = OK, body = ExternalIdentityRegistration),
         (status = NOT_FOUND, description = "Identity does not exist")
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[get("{identity_provider}/{id}")]
@@ -46,6 +52,9 @@ pub async fn get_identity(
 #[utoipa::path(context_path = "/identity/",
     responses(
         (status = OK)
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[delete("{identity_provider}/{id}")]

--- a/src/http/controllers/principal.rs
+++ b/src/http/controllers/principal.rs
@@ -16,6 +16,9 @@ use std::sync::Arc;
     request_body = Value,
     responses(
         (status = OK, body = PrincipalCreateResponse),
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[post("{schema}")]
@@ -43,6 +46,9 @@ async fn post_principal(
     responses(
         (status = OK, body = Value),
         (status = NOT_FOUND, description = "Principal does not exist")
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[get("{schema}/{id}")]

--- a/src/http/controllers/provider.rs
+++ b/src/http/controllers/provider.rs
@@ -12,6 +12,9 @@ use std::sync::Arc;
 #[utoipa::path(context_path = "/identity_provider/",
     responses(
         (status = OK),
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[post("oidc/{id}")]
@@ -37,6 +40,9 @@ pub async fn post_provider(
     responses(
         (status = OK, body = OidcIdentityProviderRegistration),
         (status = NOT_FOUND, description = "Identity provider does not exist")
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[get("oidc/{id}")]
@@ -47,6 +53,9 @@ pub async fn get_provider(id: Path<String>, data: Data<Arc<IdentityProviderRepos
 #[utoipa::path(context_path = "/identity_provider/",
     responses(
         (status = OK)
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[delete("oidc/{id}")]

--- a/src/http/controllers/schema.rs
+++ b/src/http/controllers/schema.rs
@@ -10,6 +10,9 @@ use std::sync::Arc;
     request_body = Value,
     responses(
         (status = OK),
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[post("{id}")]
@@ -28,6 +31,9 @@ async fn post_schema(
     responses(
         (status = OK, body = Value),
         (status = NOT_FOUND, description = "Schema does not exist")
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[get("{id}")]
@@ -42,6 +48,9 @@ async fn get_schema(id: Path<String>, data: Data<Arc<SchemaRepository>>) -> Resu
 #[utoipa::path(context_path = "/schema/",
     responses(
         (status = OK)
+    ),
+    security(
+        ("internal" = [])
     )
 )]
 #[delete("{id}")]

--- a/src/http/openapi.rs
+++ b/src/http/openapi.rs
@@ -25,6 +25,7 @@ struct SecurityAddon;
 impl Modify for SecurityAddon {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         let components = openapi.components.as_mut().unwrap(); // we can unwrap safely since there already is components registered.
-        components.add_security_scheme("external", SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)))
+        components.add_security_scheme("external", SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)));
+        components.add_security_scheme("internal", SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)));
     }
 }


### PR DESCRIPTION
This PR is part of https://github.com/SneaksAndData/terraform-provider-boxer/issues/10

It extends the OpenAPI specification with the "internal" auth scheme.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.