### PR TITLE
Add OpenTelemetry settings to the Boxer Helm Chart

### DIFF
--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.openTelemetry.grpcEndpoint | quote }}
             - name: OTEL_SERVICE_NAME
-              value: {{ (default (include "app.name") .Values.openTelemetry.serviceName) | quote }} # TODO: add default value
+              value: {{ (default (include "app.name" .) .Values.openTelemetry.serviceName) | quote }}
           {{- end }}
         {{- with .Values.extraEnv }}
           {{ toYaml . | nindent 12 }}

--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -72,62 +72,23 @@ spec:
             - name: BOXER__BACKEND__KUBERNETES__RESOURCE_OWNER_LABEL
               value: {{ (default (include "app.fullname" .) .Values.issuer.config.backend.kubernetes.resourceOwnerLabel) | quote }}
           {{- end }}
-        {{- if .Values.datadog.enabled }}
-            - name: DATADOG__API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.datadog.apiKeySecret | quote }}
-                  key: {{ .Values.datadog.apiKeySecretKey | quote }}
-            - name: DATADOG__ENDPOINT
-              value: {{ .Values.datadog.endpoint | quote }}
-            - name: DATADOG__APPLICATION_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-        {{- if .Values.datadog.enableOriginDetection }}
-            - name: DD_ENTITY_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
-        {{- end }}
-            - name: DATADOG__SERVICE_NAME
-              value: {{ .Values.datadog.serviceName }}
-            - name: DD_SERVICE
-              value: {{ .Values.datadog.serviceName }}
-            - name: DD_VERSION
-              value: "{{ (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}"
-            - name: DD_DOGSTATSD_URL
-              value: {{ .Values.datadog.statsdUrl | quote }}
-        {{- end }}
         {{- with .Values.extraEnv }}
           {{ toYaml . | nindent 12 }}
         {{- end }}
         {{- with .Values.extraEnvFrom }}
           {{ toYaml . | nindent 12 }}
         {{- end }}
-        {{- if .Values.datadog.enabled }}
-        - name: dsdsocket
-          mountPath: /var/run/datadog
-          readOnly: false
-        {{- end }}
         {{- with .Values.extraVolumeMounts }}
           {{ toYaml . | nindent 12 }}
         {{- end }}
         {{- with .Values.resources }}
-        resources:
+          resources:
           {{ toYaml . | nindent 12 }}
         {{- end }}
-      {{- if or .Values.extraVolumes .Values.datadog.enabled }}
       volumes:
-        {{- if .Values.datadog.enabled }}
-        - name: dsdsocket
-          hostPath:
-            path: /var/run/datadog/
-        {{- end }}
         {{- with .Values.extraVolumes }}
           {{ toYaml . | nindent 8 }}
         {{- end }}
-      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -72,6 +72,12 @@ spec:
             - name: BOXER__BACKEND__KUBERNETES__RESOURCE_OWNER_LABEL
               value: {{ (default (include "app.fullname" .) .Values.issuer.config.backend.kubernetes.resourceOwnerLabel) | quote }}
           {{- end }}
+          {{- if .Values.openTelemetry.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.openTelemetry.grpcEndpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ (default (include "app.name") .Values.openTelemetry.serviceName) | quote }} # TODO: add default value
+          {{- end }}
         {{- with .Values.extraEnv }}
           {{ toYaml . | nindent 12 }}
         {{- end }}

--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -73,10 +73,25 @@ spec:
               value: {{ (default (include "app.fullname" .) .Values.issuer.config.backend.kubernetes.resourceOwnerLabel) | quote }}
           {{- end }}
           {{- if .Values.openTelemetry.enabled }}
+            {{- if .Values.openTelemetry.grpcEndpoint }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.openTelemetry.grpcEndpoint | quote }}
+            {{else}}
+            - name: OTEL_EXPORTER_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://$(OTEL_EXPORTER_HOST):4317"
+            {{- end }}
             - name: OTEL_SERVICE_NAME
               value: {{ (default (include "app.name" .) .Values.openTelemetry.serviceName) | quote }}
+            - name: BOXER__OPENTELEMETRY__LOG_SETTINGS__ENABLED
+              value: {{ .Values.openTelemetry.logs.enabled | default "false" | quote }}
+            - name: BOXER__OPENTELEMETRY__METRICS_SETTINGS__ENABLED
+              value: {{ .Values.openTelemetry.logs.enabled | default "false" | quote }}
+            - name: BOXER__OPENTELEMETRY__TRACING_SETTINGS__ENABLED
+              value: {{ .Values.openTelemetry.logs.enabled | default "false" | quote }}
           {{- end }}
         {{- with .Values.extraEnv }}
           {{ toYaml . | nindent 12 }}

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -285,6 +285,3 @@ openTelemetry:
 
     # Set to true to enable OpenTelemetry tracing
     enabled: ""
-
-
-

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -254,28 +254,15 @@ issuer:
         # The operation timeout in seconds
         resourceOwnerLabel: ""
 
-# Observability settings for Datadog
-datadog:
+# Observability settings for OpenTelemetry
+openTelemetry:
 
   # if enabled, will set Datadog-specific environment variables on the container
   enabled: false
 
-  # Datadog endpoint to sink logs to
-  endpoint: "datadoghq.eu"
-
-  # Name for a Secret resource that contains Datadog API Key to use for log submissions
-  apiKeySecret: "secretName"
-
-  # Key in the secret that contains datadog api key
-  apiKeySecretKey: "secretKey"
-
-  # Datadog Service Name parameter
-  serviceName: "boxer-issuer"
-
-  # value to use as a DogStatsd server url
-  # Examples: udp://127.0.0.1:8125 or unix:///path/to/dsd.socket
-  # https://github.com/DataDog/datadog-go?tab=readme-ov-file#unix-domain-sockets-client
-  statsdUrl: unix:///var/run/datadog/dsd.socket
+  # Value to use as GRPC endpoint for OpenTelemetry export
+  # Defaults to
+  grpcEndpoint: ""
 
   # enables metric origin detection by setting DD_ENTITY_ID
   enableOriginDetection: true

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -261,13 +261,30 @@ openTelemetry:
   enabled: false
 
   # Value to use as GRPC endpoint for OpenTelemetry export
-  # Defaults to TODO: add default value
+  # Defaults to current node port 4317 if not set
   grpcEndpoint: ""
 
   # Value to use as GRPC endpoint for OpenTelemetry export
-  # Defaults to TODO: add default value
+  # Defaults to Chart name or nameOverride if set
   serviceName: ""
 
+  # Enable OpenTelemetry logging
+  logs:
+
+    # Set to true to enable OpenTelemetry logging
+    enabled: "false"
+
+  # Enable OpenTelemetry metrics
+  metrics:
+
+    # Set to true to enable OpenTelemetry metrics
+    enabled: "false"
+
+  # Enable OpenTelemetry tracing
+  tracing:
+
+    # Set to true to enable OpenTelemetry tracing
+    enabled: ""
 
 
 

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -261,11 +261,13 @@ openTelemetry:
   enabled: false
 
   # Value to use as GRPC endpoint for OpenTelemetry export
-  # Defaults to
+  # Defaults to TODO: add default value
   grpcEndpoint: ""
 
-  # enables metric origin detection by setting DD_ENTITY_ID
-  enableOriginDetection: true
+  # Value to use as GRPC endpoint for OpenTelemetry export
+  # Defaults to TODO: add default value
+  serviceName: ""
+
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,7 +2157,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "sha3",
  "string_cache",
  "term",
@@ -2171,7 +2171,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
- "regex-automata 0.4.9",
+ "regex-automata",
  "rustversion",
 ]
 
@@ -2277,7 +2277,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rustc_version",
  "syn",
 ]
@@ -2299,11 +2299,11 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2412,12 +2412,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2635,12 +2634,6 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2987,17 +2980,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3008,7 +2992,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3016,12 +3000,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4169,14 +4147,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -4486,22 +4464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4509,12 +4471,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=configurable-telemetry#9231aa89d79f328c43e038c6726c0338925e13be"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.10#4c5f8e5025766d2c198dbe3f304f66624e3cbec8"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
  "cedar-policy",
  "config",
  "duration-string",
+ "env_filter",
  "env_logger",
  "hmac",
  "jwt",
@@ -585,7 +586,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.9#6bb3c117b6bd1200e44153829287a2433364e1df"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=configurable-telemetry#9231aa89d79f328c43e038c6726c0338925e13be"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -594,6 +595,7 @@ dependencies = [
  "base64 0.22.1",
  "cedar-policy",
  "duration-string",
+ "env_filter",
  "futures",
  "futures-util",
  "jwt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,8 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "log",
+ "opentelemetry",
+ "opentelemetry-instrumentation-actix-web",
  "rstest",
  "schemars 0.8.22",
  "serde",
@@ -2570,6 +2572,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-actix-web"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad90191e6fce611d4128f2c4cbe51f261c72aaff4a0ae248d5f7a003c374c42d"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "serde",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2615,12 @@ dependencies = [
  "prost",
  "tonic",
 ]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cedar-policy = "4.4.0"
 config = "0.15.11"
 serde_yml = "0.0.12"
 #boxer_core = { path = "../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "configurable-telemetry" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.10" }
 schemars = "0.8.6"
 duration-string = "0.5.2"
 env_filter = "0.1.3"
@@ -37,4 +37,4 @@ opentelemetry = "0.30.0"
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../boxer-core/", features = ["testing"] }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "configurable-telemetry" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.10" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ env_filter = "0.1.3"
 kube = { version = "0.99.0", features = ["config", "client", "runtime", "derive"] }
 k8s-openapi = { version = "0.24.0", features = ["latest"] }
 
+# opentelemety
+opentelemetry-instrumentation-actix-web = "0.22.0"
+opentelemetry = "0.30.0"
+
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../boxer-core/", features = ["testing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ cedar-policy = "4.4.0"
 config = "0.15.11"
 serde_yml = "0.0.12"
 #boxer_core = { path = "../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.9" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "configurable-telemetry" }
 schemars = "0.8.6"
 duration-string = "0.5.2"
+env_filter = "0.1.3"
 
 # Kubernetes dependencies
 kube = { version = "0.99.0", features = ["config", "client", "runtime", "derive"] }
@@ -32,4 +33,4 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../boxer-core/", features = ["testing"] }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.9" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "configurable-telemetry" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use boxer_core::services::observability::open_telemetry;
 use boxer_core::services::observability::open_telemetry::metrics::init_metrics;
 use boxer_core::services::observability::open_telemetry::tracing::init_tracer;
 use env_filter::Builder;
+use opentelemetry_instrumentation_actix_web::RequestTracing;
 
 #[actix_web::main]
 async fn main() -> Result<()> {
@@ -93,6 +94,7 @@ async fn main() -> Result<()> {
     info!(host:? = &cm.listen_address.ip(); "listening on {}:{}", &cm.listen_address.ip(), &cm.listen_address.port());
     HttpServer::new(move || {
         App::new()
+            .wrap(RequestTracing::new())
             .wrap(Logger::default())
             .app_data(Data::new(token_provider.clone()))
             .app_data(Data::new(principal_service.clone()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,16 +25,36 @@ use crate::services::principal_service::PrincipalService;
 use anyhow::Result;
 use boxer_core::services::backends::kubernetes::repositories::schema_repository::SchemaRepository;
 use boxer_core::services::observability::composed_logger::ComposedLogger;
+use boxer_core::services::observability::open_telemetry;
+use env_filter::Builder;
 
 #[actix_web::main]
 async fn main() -> Result<()> {
-    ComposedLogger::new()
-        // .with_logger(open_telemetry::logging::init_logger()?)
-        .with_logger(Box::new(env_logger::Builder::from_default_env().build()))
-        .with_global_level(log::LevelFilter::Info)
-        .init()?;
+    let mut builder = Builder::new();
+
+    let filter = if let Ok(ref filter) = std::env::var("RUST_LOG") {
+        builder.parse(filter);
+        builder.build()
+    } else {
+        Builder::default().parse("info").build()
+    };
 
     let cm = AppSettings::new()?;
+
+    let logger = ComposedLogger::new();
+    let logger = {
+        if cm.opentelemetry.log_settings.enabled {
+            logger.with_logger(open_telemetry::logging::init_logger()?)
+        } else {
+            logger
+        }
+    };
+
+    logger
+        .with_logger(Box::new(env_logger::Builder::from_default_env().build()))
+        .with_global_level(filter)
+        .init()?;
+
     info!("Configuration manager started");
 
     let current_backend = load_backend(cm.get_backend_type(), &cm).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ use anyhow::Result;
 use boxer_core::services::backends::kubernetes::repositories::schema_repository::SchemaRepository;
 use boxer_core::services::observability::composed_logger::ComposedLogger;
 use boxer_core::services::observability::open_telemetry;
+use boxer_core::services::observability::open_telemetry::metrics::init_metrics;
+use boxer_core::services::observability::open_telemetry::tracing::init_tracer;
 use env_filter::Builder;
 
 #[actix_web::main]
@@ -56,6 +58,16 @@ async fn main() -> Result<()> {
         .init()?;
 
     info!("Configuration manager started");
+
+    if cm.opentelemetry.tracing_settings.enabled {
+        info!("Tracing is enabled, starting tracer...");
+        init_tracer()?;
+    }
+
+    if cm.opentelemetry.metrics_settings.enabled {
+        info!("Metrics is enabled, starting metrics...");
+        init_metrics()?;
+    }
 
     let current_backend = load_backend(cm.get_backend_type(), &cm).await?;
 

--- a/src/services/configuration/models.rs
+++ b/src/services/configuration/models.rs
@@ -1,4 +1,5 @@
 use crate::services::backends::base::BackendType;
+use boxer_core::services::observability::open_telemetry::settings::OpenTelemetrySettings;
 use duration_string::DurationString;
 use serde::Deserialize;
 use std::net::SocketAddr;
@@ -29,4 +30,5 @@ pub struct AppSettings {
     pub listen_address: SocketAddr,
     pub init: InitializationSettings,
     pub backend: BackendSettings,
+    pub opentelemetry: OpenTelemetrySettings,
 }


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/boxer-core/issues/33

## Scope

Implemented:
- Opentelemetry integration from boxer-core
- Opentelemetry settings in the Helm Chart

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.