### PR TITLE
Update helm chart with liveness and readiness probes

### DIFF
--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -63,6 +63,20 @@ spec:
             - containerPort: {{ .Values.issuer.config.port }}
               name: http
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            {{- with .Values.livenessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            {{- with .Values.readinessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- with .Values.securityContext }}
           securityContext:
         {{ toYaml . | nindent 12 }}

--- a/.helm/values.yaml
+++ b/.helm/values.yaml
@@ -93,6 +93,26 @@ tolerations: { }
 # Node labels for pod assignment
 affinity: { }
 
+# Additional settings for the liveness probe that hits /health on the http port.
+# Merged into the probe spec; httpGet path and port are managed by the chart.
+livenessProbe: { }
+# Example:
+#
+#  initialDelaySeconds: 10
+#  periodSeconds: 10
+#  timeoutSeconds: 1
+#  failureThreshold: 3
+
+# Additional settings for the readiness probe that hits /health/ready on the http port.
+# Merged into the probe spec; httpGet path and port are managed by the chart.
+readinessProbe: { }
+# Example:
+#
+#  initialDelaySeconds: 5
+#  periodSeconds: 10
+#  timeoutSeconds: 1
+#  failureThreshold: 3
+
 # Security context settings for the container
 securityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
Part of #103

Implemented:
- Add liveness and readiness probes to helm chart
