### PR TITLE
Fixes the types for integration tests

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::audit::AuditService;
+use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
 use boxer_core::services::observability::composed_logger::ComposedLogger;
 use boxer_core::services::observability::open_telemetry;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use boxer_core::services::audit::AuditService;
 use boxer_core::services::audit::log_audit_service::LogAuditService;
+use boxer_core::services::audit::AuditService;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
 use boxer_core::services::observability::composed_logger::ComposedLogger;
 use boxer_core::services::observability::open_telemetry;
@@ -96,7 +96,7 @@ async fn main() -> Result<()> {
 
     info!(host:? = &cm.listen_address.ip(); "listening on {}:{}", &cm.listen_address.ip(), &cm.listen_address.port());
 
-    boxer_issuer_http::start_api_server(
+    let server = boxer_issuer_http::start_api_server(
         current_backend,
         token_provider,
         audit_service,
@@ -104,6 +104,7 @@ async fn main() -> Result<()> {
         readiness_state,
         principal_service,
         cm,
-    )
-    .await
+    )?;
+
+    server.await.map_err(anyhow::Error::from)
 }

--- a/crates/boxer-issuer-http/src/lib.rs
+++ b/crates/boxer-issuer-http/src/lib.rs
@@ -3,12 +3,12 @@ pub mod models;
 pub mod services;
 
 use actix_web::dev::Server;
-use actix_web::middleware::{from_fn, Logger};
+use actix_web::middleware::{Logger, from_fn};
 use actix_web::web::Data;
 use actix_web::{App, HttpServer};
 use log::info;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 

--- a/crates/boxer-issuer-http/src/lib.rs
+++ b/crates/boxer-issuer-http/src/lib.rs
@@ -2,16 +2,18 @@ pub mod http;
 pub mod models;
 pub mod services;
 
-use actix_web::middleware::{Logger, from_fn};
+use actix_web::dev::Server;
+use actix_web::middleware::{from_fn, Logger};
 use actix_web::web::Data;
 use actix_web::{App, HttpServer};
 use log::info;
-use services::token_service::TokenService;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+use crate::services::principal_service::PrincipalServiceTrait;
+use crate::services::token_service::TokenProvider;
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
 use boxer_core::http::middleware::logging::custom_error_logging;
@@ -26,24 +28,23 @@ use services::backends::kubernetes::identity_provider_repository::IdentityProvid
 use services::backends::kubernetes::identity_repository::IdentityRepository;
 use services::backends::kubernetes::principal_repository::PrincipalRepository;
 use services::configuration::models::AppSettings;
-use services::principal_service::PrincipalService;
 
-pub async fn start_api_server(
+pub fn start_api_server(
     current_backend: Arc<dyn IssuerBackend>,
-    token_provider: Arc<TokenService>,
+    token_provider: Arc<dyn TokenProvider>,
     audit_service: Arc<dyn AuditService>,
     audit_writer: Arc<dyn AuditWriter>,
     readiness_state: Arc<AtomicBool>,
-    principal_service: Arc<PrincipalService>,
+    principal_service: Arc<dyn PrincipalServiceTrait>,
     cm: AppSettings,
-) -> Result<()> {
+) -> Result<Server, anyhow::Error> {
     let schemas_repository: Arc<SchemaRepository> = current_backend.get();
     let entities_repository: Arc<PrincipalRepository> = current_backend.get();
     let identity_repository: Arc<IdentityRepository> = current_backend.get();
     let identity_provider_repository: Arc<IdentityProviderRepository> = current_backend.get();
 
     info!(host:? = &cm.listen_address.ip(); "listening on {}:{}", &cm.listen_address.ip(), &cm.listen_address.port());
-    HttpServer::new(move || {
+    let server_builder = HttpServer::new(move || {
         App::new()
             .wrap(RequestTracing::new())
             .wrap(Logger::default())
@@ -60,8 +61,6 @@ pub async fn start_api_server(
             .service(health::urls())
             .service(SwaggerUi::new("/swagger/{_:.*}").url("/api-docs/openapi.json", ApiDoc::openapi()))
     })
-    .bind(cm.listen_address.clone())?
-    .run()
-    .await
-    .map_err(anyhow::Error::from)
+    .bind(cm.listen_address.clone())?;
+    Ok(server_builder.run())
 }

--- a/crates/boxer-issuer-http/src/services/principal_service.rs
+++ b/crates/boxer-issuer-http/src/services/principal_service.rs
@@ -1,7 +1,9 @@
 use crate::models::api::external::identity::ExternalIdentity;
 use crate::services::backends::kubernetes::identity_repository::IdentityRepository;
-use crate::services::backends::kubernetes::principal_repository::PrincipalRepository;
 use crate::services::backends::kubernetes::principal_repository::principal_identity::PrincipalIdentity;
+use crate::services::backends::kubernetes::principal_repository::PrincipalRepository;
+use anyhow::Result;
+use async_trait::async_trait;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
 use cedar_policy::{EntityUid, SchemaFragment};
 use principal::Principal;
@@ -10,17 +12,17 @@ use std::sync::Arc;
 
 pub mod principal;
 
+#[async_trait]
+pub trait PrincipalServiceTrait: Send + Sync + 'static {
+    async fn get_principal(&self, external_identity: ExternalIdentity) -> Result<Principal>;
+    async fn get_validator_schema(&self, external_identity: ExternalIdentity) -> Result<String>;
+    async fn get_schemas(&self, schema_id: String) -> Result<SchemaFragment, anyhow::Error>;
+}
+
 pub struct PrincipalService {
     identities: Arc<IdentityRepository>,
     principals: Arc<PrincipalRepository>,
     schema_repository: Arc<SchemaRepository>,
-}
-
-impl PrincipalService {
-    pub async fn get_schemas(&self, schema_id: String) -> Result<SchemaFragment, anyhow::Error> {
-        let schema = self.schema_repository.get(schema_id).await?;
-        Ok(schema)
-    }
 }
 
 impl PrincipalService {
@@ -35,8 +37,11 @@ impl PrincipalService {
             schema_repository,
         }
     }
+}
 
-    pub async fn get_principal(&self, external_identity: ExternalIdentity) -> Result<Principal, anyhow::Error> {
+#[async_trait]
+impl PrincipalServiceTrait for PrincipalService {
+    async fn get_principal(&self, external_identity: ExternalIdentity) -> Result<Principal, anyhow::Error> {
         let registration = self
             .identities
             .get((external_identity.identity_provider, external_identity.user_id))
@@ -48,11 +53,16 @@ impl PrincipalService {
         Ok(Principal::new(entity.into(), schema_id))
     }
 
-    pub async fn get_validator_schema(&self, external_identity: ExternalIdentity) -> Result<String, anyhow::Error> {
+    async fn get_validator_schema(&self, external_identity: ExternalIdentity) -> Result<String, anyhow::Error> {
         let registration = self
             .identities
             .get((external_identity.identity_provider, external_identity.user_id))
             .await?;
         Ok(registration.validator_schema)
+    }
+
+    async fn get_schemas(&self, schema_id: String) -> Result<SchemaFragment, anyhow::Error> {
+        let schema = self.schema_repository.get(schema_id).await?;
+        Ok(schema)
     }
 }

--- a/crates/boxer-issuer-http/src/services/principal_service.rs
+++ b/crates/boxer-issuer-http/src/services/principal_service.rs
@@ -1,7 +1,7 @@
 use crate::models::api::external::identity::ExternalIdentity;
 use crate::services::backends::kubernetes::identity_repository::IdentityRepository;
-use crate::services::backends::kubernetes::principal_repository::principal_identity::PrincipalIdentity;
 use crate::services::backends::kubernetes::principal_repository::PrincipalRepository;
+use crate::services::backends::kubernetes::principal_repository::principal_identity::PrincipalIdentity;
 use anyhow::Result;
 use async_trait::async_trait;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;

--- a/crates/boxer-issuer-http/src/services/token_service.rs
+++ b/crates/boxer-issuer-http/src/services/token_service.rs
@@ -1,6 +1,6 @@
 use crate::models::api::external::identity_provider::ExternalIdentityProvider;
 use crate::services::identity_validator_provider::ExternalIdentityValidatorProvider;
-use crate::services::principal_service::PrincipalService;
+use crate::services::principal_service::{PrincipalService, PrincipalServiceTrait};
 use async_trait::async_trait;
 use boxer_core::contracts::internal_token::v1::token::InternalToken;
 use boxer_core::models::external_token::ExternalToken;
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 #[async_trait]
-pub trait TokenProvider {
+pub trait TokenProvider: Send + Sync + 'static {
     async fn issue_token(
         &self,
         external_identity_provider: ExternalIdentityProvider,
@@ -32,7 +32,7 @@ pub trait TokenProvider {
 
 pub struct TokenService {
     validators: Arc<dyn ExternalIdentityValidatorProvider + Send + Sync>,
-    principal_service: Arc<PrincipalService>,
+    principal_service: Arc<dyn PrincipalServiceTrait>,
     encrypt_secret: Arc<Vec<u8>>,
     audience: String,
     key_id: String,


### PR DESCRIPTION
Part of #71
Also related to #70

Changes required for integration tests:
- Added `#[async_trait]` to all async traits.
- Added required supertraits to all traits.
- Decomposed the service creation and from the awaiting of it's run result. This is required as in integration tests we will pass the `Server` object directly to the `tokio::spawn` call.


## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.