### PR TITLE
Unify the server startup

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use boxer_core::services::audit::AuditService;
 use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::observability::composed_logger::ComposedLogger;
 use boxer_core::services::observability::open_telemetry;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1,24 +1,17 @@
 use boxer_issuer_http::services::configuration::base::initialization_configuration_manager::InitializationConfigurationManager;
-use boxer_issuer_http::services::token_service::TokenService;
 use log::info;
 use std::sync::Arc;
 
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use boxer_core::services::audit::AuditService;
 use boxer_core::services::audit::log_audit_service::LogAuditService;
-use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
+use boxer_core::services::audit::AuditService;
 use boxer_core::services::observability::composed_logger::ComposedLogger;
 use boxer_core::services::observability::open_telemetry;
 use boxer_core::services::observability::open_telemetry::metrics::init_metrics;
-use boxer_core::services::observability::open_telemetry::metrics::provider::MetricsProvider;
 use boxer_core::services::observability::open_telemetry::tracing::init_tracer;
 use boxer_issuer_http::services::backends::base::load_backend;
-use boxer_issuer_http::services::backends::kubernetes::identity_repository::IdentityRepository;
-use boxer_issuer_http::services::backends::kubernetes::principal_repository::PrincipalRepository;
 use boxer_issuer_http::services::configuration::models::AppSettings;
-use boxer_issuer_http::services::identity_validator_provider::ExternalIdentityValidatorProvider;
-use boxer_issuer_http::services::principal_service::PrincipalService;
 use env_filter::Builder;
 
 const ROOT_METRICS_NAMESPACE: &str = "boxer-issuer";

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::audit::AuditService;
+use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::observability::composed_logger::ComposedLogger;
 use boxer_core::services::observability::open_telemetry;
 use boxer_core::services::observability::open_telemetry::metrics::init_metrics;

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -63,48 +63,11 @@ async fn main() -> Result<()> {
     }
 
     let current_backend = load_backend(cm.get_backend_type(), &cm).await?;
-    let readiness_state = current_backend.readiness_state();
-
-    let validator_provider: Arc<dyn ExternalIdentityValidatorProvider + Send + Sync> = current_backend.get();
-
-    let schemas_repository: Arc<SchemaRepository> = current_backend.get();
-    let entities_repository: Arc<PrincipalRepository> = current_backend.get();
-    let identity_repository: Arc<IdentityRepository> = current_backend.get();
-
-    let principal_service = Arc::new(PrincipalService::new(
-        identity_repository.clone(),
-        entities_repository.clone(),
-        schemas_repository.clone(),
-    ));
-
-    let token_provider = Arc::new(TokenService::new(
-        validator_provider.clone(),
-        principal_service.clone(),
-        cm.get_signing_key(),
-        cm.get_key_id(),
-        cm.get_audience(),
-        cm.get_issuer(),
-        cm.get_content_encryption(),
-        MetricsProvider::new(ROOT_METRICS_NAMESPACE, cm.instance_name.clone()),
-    ));
-
-    // The audit_service variable is deprecated, use audit_writer instead.
-    // Will be removed in the next releases.
-    let audit_service: Arc<dyn AuditService> = Arc::new(LogAuditService::new());
-
     let audit_writer: Arc<dyn AuditWriter> = Arc::new(LogAuditService::new());
 
     info!(host:? = &cm.listen_address.ip(); "listening on {}:{}", &cm.listen_address.ip(), &cm.listen_address.port());
 
-    let server = boxer_issuer_http::start_api_server(
-        current_backend,
-        token_provider,
-        audit_service,
-        audit_writer,
-        readiness_state,
-        principal_service,
-        cm,
-    )?;
+    let server = boxer_issuer_http::start_api_server(current_backend, audit_writer, cm, ROOT_METRICS_NAMESPACE)?;
 
     server.await.map_err(anyhow::Error::from)
 }

--- a/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
+++ b/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 #[get("/token/{identity_provider}")]
 pub async fn token(
     external_token: ReqData<ExternalToken>,
-    data: Data<Arc<TokenService>>,
+    data: Data<Arc<dyn TokenProvider>>,
     identity_provider: Path<String>,
 ) -> actix_web::Result<String> {
     let ip = ExternalIdentityProvider::from(identity_provider.to_string());

--- a/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
+++ b/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
@@ -1,5 +1,5 @@
 use crate::models::api::external::identity_provider::ExternalIdentityProvider;
-use crate::services::token_service::{TokenProvider, TokenService};
+use crate::services::token_service::TokenProvider;
 use actix_web::get;
 use actix_web::web::{Data, Path, ReqData};
 use boxer_core::models::external_token::ExternalToken;

--- a/crates/boxer-issuer-http/src/lib.rs
+++ b/crates/boxer-issuer-http/src/lib.rs
@@ -12,13 +12,17 @@ use std::sync::atomic::AtomicBool;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::services::principal_service::PrincipalServiceTrait;
-use crate::services::token_service::TokenProvider;
+use crate::services::configuration::base::initialization_configuration_manager::InitializationConfigurationManager;
+use crate::services::identity_validator_provider::ExternalIdentityValidatorProvider;
+use crate::services::principal_service::{PrincipalService, PrincipalServiceTrait};
+use crate::services::token_service::{TokenProvider, TokenService};
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
 use boxer_core::http::middleware::logging::custom_error_logging;
 use boxer_core::services::audit::AuditService;
+use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
+use boxer_core::services::observability::open_telemetry::metrics::provider::MetricsProvider;
 use http::controllers::v1;
 use http::health;
 use http::openapi::ApiDoc;
@@ -31,17 +35,35 @@ use services::configuration::models::AppSettings;
 
 pub fn start_api_server(
     current_backend: Arc<dyn IssuerBackend>,
-    token_provider: Arc<dyn TokenProvider>,
-    audit_service: Arc<dyn AuditService>,
     audit_writer: Arc<dyn AuditWriter>,
-    readiness_state: Arc<AtomicBool>,
-    principal_service: Arc<dyn PrincipalServiceTrait>,
     cm: AppSettings,
+    root_metrics_namespace: &'static str,
 ) -> Result<Server, anyhow::Error> {
     let schemas_repository: Arc<SchemaRepository> = current_backend.get();
     let entities_repository: Arc<PrincipalRepository> = current_backend.get();
     let identity_repository: Arc<IdentityRepository> = current_backend.get();
     let identity_provider_repository: Arc<IdentityProviderRepository> = current_backend.get();
+    let validator_provider: Arc<dyn ExternalIdentityValidatorProvider + Send + Sync> = current_backend.get();
+    let readiness_state = current_backend.readiness_state();
+    let principal_service = Arc::new(PrincipalService::new(
+        identity_repository.clone(),
+        entities_repository.clone(),
+        schemas_repository.clone(),
+    ));
+    let token_provider: Arc<dyn TokenProvider> = Arc::new(TokenService::new(
+        validator_provider.clone(),
+        principal_service.clone(),
+        cm.get_signing_key(),
+        cm.get_key_id(),
+        cm.get_audience(),
+        cm.get_issuer(),
+        cm.get_content_encryption(),
+        MetricsProvider::new(root_metrics_namespace, cm.instance_name.clone()),
+    ));
+
+    // The audit_service variable is deprecated, use audit_writer instead.
+    // Will be removed in the next releases.
+    let audit_service: Arc<dyn AuditService> = Arc::new(LogAuditService::new());
 
     info!(host:? = &cm.listen_address.ip(); "listening on {}:{}", &cm.listen_address.ip(), &cm.listen_address.port());
     let server_builder = HttpServer::new(move || {

--- a/crates/boxer-issuer-http/src/lib.rs
+++ b/crates/boxer-issuer-http/src/lib.rs
@@ -3,12 +3,12 @@ pub mod models;
 pub mod services;
 
 use actix_web::dev::Server;
-use actix_web::middleware::{from_fn, Logger};
+use actix_web::middleware::{Logger, from_fn};
 use actix_web::web::Data;
 use actix_web::{App, HttpServer};
 use log::info;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -19,8 +19,8 @@ use crate::services::token_service::{TokenProvider, TokenService};
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
 use boxer_core::http::middleware::logging::custom_error_logging;
-use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::audit::AuditService;
+use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
 use boxer_core::services::observability::open_telemetry::metrics::provider::MetricsProvider;
 use http::controllers::v1;

--- a/crates/boxer-issuer-http/src/lib.rs
+++ b/crates/boxer-issuer-http/src/lib.rs
@@ -3,24 +3,24 @@ pub mod models;
 pub mod services;
 
 use actix_web::dev::Server;
-use actix_web::middleware::{Logger, from_fn};
+use actix_web::middleware::{from_fn, Logger};
 use actix_web::web::Data;
 use actix_web::{App, HttpServer};
 use log::info;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::services::configuration::base::initialization_configuration_manager::InitializationConfigurationManager;
 use crate::services::identity_validator_provider::ExternalIdentityValidatorProvider;
-use crate::services::principal_service::{PrincipalService, PrincipalServiceTrait};
+use crate::services::principal_service::PrincipalService;
 use crate::services::token_service::{TokenProvider, TokenService};
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
 use boxer_core::http::middleware::logging::custom_error_logging;
-use boxer_core::services::audit::AuditService;
 use boxer_core::services::audit::log_audit_service::LogAuditService;
+use boxer_core::services::audit::AuditService;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
 use boxer_core::services::observability::open_telemetry::metrics::provider::MetricsProvider;
 use http::controllers::v1;

--- a/crates/boxer-issuer-http/src/lib.rs
+++ b/crates/boxer-issuer-http/src/lib.rs
@@ -3,7 +3,7 @@ pub mod models;
 pub mod services;
 
 use actix_web::dev::Server;
-use actix_web::middleware::{from_fn, Logger};
+use actix_web::middleware::{Logger, from_fn};
 use actix_web::web::Data;
 use actix_web::{App, HttpServer};
 use log::info;
@@ -18,8 +18,8 @@ use crate::services::token_service::{TokenProvider, TokenService};
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
 use boxer_core::http::middleware::logging::custom_error_logging;
-use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::audit::AuditService;
+use boxer_core::services::audit::log_audit_service::LogAuditService;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
 use boxer_core::services::observability::open_telemetry::metrics::provider::MetricsProvider;
 use http::controllers::v1;

--- a/crates/boxer-issuer-http/src/lib.rs
+++ b/crates/boxer-issuer-http/src/lib.rs
@@ -3,12 +3,11 @@ pub mod models;
 pub mod services;
 
 use actix_web::dev::Server;
-use actix_web::middleware::{Logger, from_fn};
+use actix_web::middleware::{from_fn, Logger};
 use actix_web::web::Data;
 use actix_web::{App, HttpServer};
 use log::info;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -19,8 +18,8 @@ use crate::services::token_service::{TokenProvider, TokenService};
 use anyhow::Result;
 use boxer_core::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
 use boxer_core::http::middleware::logging::custom_error_logging;
-use boxer_core::services::audit::AuditService;
 use boxer_core::services::audit::log_audit_service::LogAuditService;
+use boxer_core::services::audit::AuditService;
 use boxer_core::services::backends::kubernetes::kubernetes_repository::schema_repository::SchemaRepository;
 use boxer_core::services::observability::open_telemetry::metrics::provider::MetricsProvider;
 use http::controllers::v1;

--- a/crates/boxer-issuer-http/src/services/token_service.rs
+++ b/crates/boxer-issuer-http/src/services/token_service.rs
@@ -1,6 +1,6 @@
 use crate::models::api::external::identity_provider::ExternalIdentityProvider;
 use crate::services::identity_validator_provider::ExternalIdentityValidatorProvider;
-use crate::services::principal_service::{PrincipalService, PrincipalServiceTrait};
+use crate::services::principal_service::PrincipalServiceTrait;
 use async_trait::async_trait;
 use boxer_core::contracts::internal_token::v1::token::InternalToken;
 use boxer_core::models::external_token::ExternalToken;
@@ -93,7 +93,7 @@ impl TokenProvider for TokenService {
 impl TokenService {
     pub fn new(
         validators: Arc<dyn ExternalIdentityValidatorProvider + Send + Sync>,
-        principal_service: Arc<PrincipalService>,
+        principal_service: Arc<dyn PrincipalServiceTrait>,
         encrypt_secret: Arc<Vec<u8>>,
         key_id: String,
         audience: String,


### PR DESCRIPTION
Part of #71
Also related to #70

This PR moves the launching the backend services from the main method to the start_api_server method which removes the code duplication between the `main` function and the integration tests setup.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.