### PR TITLE
Implement an ability to issue v2 tokens form boxer-issuer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,8 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
 
-      - name: Install just, cargo-llvm-cov, cargo-nextest
-        uses: taiki-e/install-action@v2.62.33
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2.85.11
         with:
           tool: cargo-llvm-cov
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=token-v2-only#36b57b983013a9e9ca5e8c835532957ee8d333fc"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.35#f4a8762a3b675d4491f562599337848b24f74fd3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.32#9d3c0f2c2370f4267efca2fbd2ef519314553ca7"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=token-v2-only#4aafb4bf56932bd76917b607d1c37dd74d1a9627"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=token-v2-only#4aafb4bf56932bd76917b607d1c37dd74d1a9627"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=token-v2-only#36b57b983013a9e9ca5e8c835532957ee8d333fc"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.11.5"
 opentelemetry-instrumentation-actix-web = "0.22.0"
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "token-v2-only" }
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.11.5"
 opentelemetry-instrumentation-actix-web = "0.22.0"
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "token-v2-only" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
 

--- a/crates/boxer-issuer-http/Cargo.toml
+++ b/crates/boxer-issuer-http/Cargo.toml
@@ -31,10 +31,10 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 # opentelemety
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "token-v2-only" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
 opentelemetry-instrumentation-actix-web = "0.24.0"
 
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "token-v2-only" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }

--- a/crates/boxer-issuer-http/Cargo.toml
+++ b/crates/boxer-issuer-http/Cargo.toml
@@ -31,10 +31,10 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 # opentelemety
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "token-v2-only" }
 opentelemetry-instrumentation-actix-web = "0.24.0"
 
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "token-v2-only" }

--- a/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
+++ b/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
@@ -2,6 +2,7 @@ use actix_web::error::ErrorInternalServerError;
 use actix_web::get;
 use actix_web::web::{Data, Path, ReqData};
 use boxer_core::models::external_token::ExternalToken;
+use boxer_core::services::audit::chained::audit_event::intermediate_audit_event::IntermediateAuditEvent;
 use boxer_core::services::audit::chained::audit_event::AuditEvent;
 use boxer_core::services::token_service::internal_token_service::external_identity_validator_provider::external_identity_provider::ExternalIdentityProvider;
 use boxer_core::services::token_service::TokenService;
@@ -22,10 +23,17 @@ pub async fn token(
     audit_event: ReqData<AuditEvent>,
 ) -> actix_web::Result<String> {
     let ip = ExternalIdentityProvider::from(identity_provider.to_string());
-    let token_audit_event = audit_event
-        .into_inner()
-        .external_token_data()
-        .ok_or(ErrorInternalServerError("No token data in audit_event"))?;
+    let audit_event = audit_event.into_inner();
+    let token_audit_event = match audit_event {
+        AuditEvent::Intermediate(IntermediateAuditEvent {
+            external_token: Some(token_event),
+            ..
+        }) => Ok(token_event),
+        _ => Err(ErrorInternalServerError(format!(
+            "Unexpected audit event: {:?}",
+            audit_event
+        ))),
+    }?;
     token_service
         .into_inner()
         .issue_internal_token(ip, external_token.into_inner(), token_audit_event)

--- a/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
+++ b/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
@@ -1,6 +1,8 @@
+use actix_web::error::ErrorInternalServerError;
 use actix_web::get;
 use actix_web::web::{Data, Path, ReqData};
 use boxer_core::models::external_token::ExternalToken;
+use boxer_core::services::audit::chained::audit_event::AuditEvent;
 use boxer_core::services::token_service::internal_token_service::external_identity_validator_provider::external_identity_provider::ExternalIdentityProvider;
 use boxer_core::services::token_service::TokenService;
 use log::error;
@@ -17,11 +19,16 @@ pub async fn token(
     external_token: ReqData<ExternalToken>,
     token_service: Data<Arc<dyn TokenService>>,
     identity_provider: Path<String>,
+    audit_event: Data<AuditEvent>,
 ) -> actix_web::Result<String> {
     let ip = ExternalIdentityProvider::from(identity_provider.to_string());
+    let token_audit_event = audit_event
+        .into_inner()
+        .external_token_data()
+        .ok_or(ErrorInternalServerError("No token data in audit_event"))?;
     token_service
         .into_inner()
-        .issue_internal_token(ip, external_token.into_inner())
+        .issue_internal_token(ip, external_token.into_inner(), token_audit_event)
         .await
         .map_err(|err| {
             error!("Failed to issue internal token: {}", err);

--- a/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
+++ b/crates/boxer-issuer-http/src/http/controllers/v1/token.rs
@@ -19,7 +19,7 @@ pub async fn token(
     external_token: ReqData<ExternalToken>,
     token_service: Data<Arc<dyn TokenService>>,
     identity_provider: Path<String>,
-    audit_event: Data<AuditEvent>,
+    audit_event: ReqData<AuditEvent>,
 ) -> actix_web::Result<String> {
     let ip = ExternalIdentityProvider::from(identity_provider.to_string());
     let token_audit_event = audit_event

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 boxer-issuer-http = { path = "../boxer-issuer-http" }
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "token-v2-only" }
 actix-web = "4.14.0"
 tokio = "1.52.3"
 anyhow = "1.0.103"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 boxer-issuer-http = { path = "../boxer-issuer-http" }
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "token-v2-only" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
 actix-web = "4.14.0"
 tokio = "1.52.3"
 anyhow = "1.0.103"

--- a/integration-tests/helm/setup/Chart.lock
+++ b/integration-tests/helm/setup/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v0.0.5
 - name: boxer-validator-nginx
   repository: oci://ghcr.io/sneaksanddata/helm
-  version: v0.0.17-1-g22439cc
-digest: sha256:d985ab2ac4a035bb65c6fc23b00949d7547b8bae7c80aea2b79b619e3e44b48c
-generated: "2026-07-23T15:16:26.718768+02:00"
+  version: v0.0.18
+digest: sha256:01d48c14b649e15f813a37d7e218501eb5432257bfca2d3dee9e4b3beb3da7ed
+generated: "2026-07-23T15:53:29.17753+02:00"

--- a/integration-tests/helm/setup/Chart.lock
+++ b/integration-tests/helm/setup/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v0.0.5
 - name: boxer-validator-nginx
   repository: oci://ghcr.io/sneaksanddata/helm
-  version: v0.0.18
-digest: sha256:01d48c14b649e15f813a37d7e218501eb5432257bfca2d3dee9e4b3beb3da7ed
-generated: "2026-07-23T15:53:29.17753+02:00"
+  version: v0.0.19
+digest: sha256:bdf482e2856f03fe16291b73e7e820221ddbd2cfb00078035fe7c3b4de8b8274
+generated: "2026-08-11T11:50:46.071408+02:00"

--- a/integration-tests/helm/setup/Chart.lock
+++ b/integration-tests/helm/setup/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v0.0.5
 - name: boxer-validator-nginx
   repository: oci://ghcr.io/sneaksanddata/helm
-  version: v0.0.17
-digest: sha256:70822803a64a1d388703bc3017b9540dac2d8a9ada1b49faf93ab10f3e2c7eb7
-generated: "2026-07-16T13:06:53.545228+02:00"
+  version: v0.0.17-1-g22439cc
+digest: sha256:d985ab2ac4a035bb65c6fc23b00949d7547b8bae7c80aea2b79b619e3e44b48c
+generated: "2026-07-23T15:16:26.718768+02:00"

--- a/integration-tests/helm/setup/Chart.yaml
+++ b/integration-tests/helm/setup/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: v0.0.5
     repository: oci://ghcr.io/sneaksanddata/helm
   - name: boxer-validator-nginx
-    version: v0.0.17
+    version: v0.0.17-1-g22439cc
     repository: oci://ghcr.io/sneaksanddata/helm

--- a/integration-tests/helm/setup/Chart.yaml
+++ b/integration-tests/helm/setup/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: v0.0.5
     repository: oci://ghcr.io/sneaksanddata/helm
   - name: boxer-validator-nginx
-    version: v0.0.18
+    version: v0.0.19
     repository: oci://ghcr.io/sneaksanddata/helm

--- a/integration-tests/helm/setup/Chart.yaml
+++ b/integration-tests/helm/setup/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: v0.0.5
     repository: oci://ghcr.io/sneaksanddata/helm
   - name: boxer-validator-nginx
-    version: v0.0.17-1-g22439cc
+    version: v0.0.18
     repository: oci://ghcr.io/sneaksanddata/helm


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/boxer-core/issues/71

## Scope

Implemented:
- Boxer-core version was updated and the issuer now issues v2 tokens.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.