### PR TITLE
Bump `boxer-core` version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,8 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
 
-      - name: Install just, cargo-llvm-cov, cargo-nextest
-        uses: taiki-e/install-action@v2.62.33
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2.85.11
         with:
           tool: cargo-llvm-cov
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=polish-error-handling#5b3eaac9ecb7cf1db7dbe3b92b5fa15600ebcaa3"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.32#9d3c0f2c2370f4267efca2fbd2ef519314553ca7"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.32#9d3c0f2c2370f4267efca2fbd2ef519314553ca7"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.34#262df89678275af574bd5fce87d14f57d6a29cf9"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.32#9d3c0f2c2370f4267efca2fbd2ef519314553ca7"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?branch=polish-error-handling#5b3eaac9ecb7cf1db7dbe3b92b5fa15600ebcaa3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.34#262df89678275af574bd5fce87d14f57d6a29cf9"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.35#f4a8762a3b675d4491f562599337848b24f74fd3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.11.5"
 opentelemetry-instrumentation-actix-web = "0.22.0"
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.34" }
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.11.5"
 opentelemetry-instrumentation-actix-web = "0.22.0"
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "polish-error-handling" }
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.11.5"
 opentelemetry-instrumentation-actix-web = "0.22.0"
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "polish-error-handling" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
 

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.11.5"
 opentelemetry-instrumentation-actix-web = "0.22.0"
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.34" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
 

--- a/crates/boxer-issuer-http/Cargo.toml
+++ b/crates/boxer-issuer-http/Cargo.toml
@@ -31,10 +31,10 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 # opentelemety
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.34" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
 opentelemetry-instrumentation-actix-web = "0.24.0"
 
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.34" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }

--- a/crates/boxer-issuer-http/Cargo.toml
+++ b/crates/boxer-issuer-http/Cargo.toml
@@ -31,10 +31,10 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 # opentelemety
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "polish-error-handling" }
 opentelemetry-instrumentation-actix-web = "0.24.0"
 
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "polish-error-handling" }

--- a/crates/boxer-issuer-http/Cargo.toml
+++ b/crates/boxer-issuer-http/Cargo.toml
@@ -31,10 +31,10 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 # opentelemety
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "polish-error-handling" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
 opentelemetry-instrumentation-actix-web = "0.24.0"
 
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "polish-error-handling" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }

--- a/crates/boxer-issuer-http/Cargo.toml
+++ b/crates/boxer-issuer-http/Cargo.toml
@@ -31,10 +31,10 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 # opentelemety
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.34" }
 opentelemetry-instrumentation-actix-web = "0.24.0"
 
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.34" }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 boxer-issuer-http = { path = "../boxer-issuer-http" }
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.34" }
 actix-web = "4.14.0"
 tokio = "1.52.3"
 anyhow = "1.0.103"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 boxer-issuer-http = { path = "../boxer-issuer-http" }
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.34" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
 actix-web = "4.14.0"
 tokio = "1.52.3"
 anyhow = "1.0.103"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 boxer-issuer-http = { path = "../boxer-issuer-http" }
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "polish-error-handling" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
 actix-web = "4.14.0"
 tokio = "1.52.3"
 anyhow = "1.0.103"

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 boxer-issuer-http = { path = "../boxer-issuer-http" }
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.32" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", branch = "polish-error-handling" }
 actix-web = "4.14.0"
 tokio = "1.52.3"
 anyhow = "1.0.103"


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/boxer-core/issues/71 

This PR unifies the boxer-core version across services and fixes the code coverage build.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.