### PR TITLE
Bump boxer-core version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "boxer_core"
 version = "0.1.0"
-source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.35#f4a8762a3b675d4491f562599337848b24f74fd3"
+source = "git+https://github.com/SneaksAndData/boxer-core.git?tag=v0.0.36#d7986f72a898be5eefc2ddbb1a93102c0b8c7337"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.11.5"
 opentelemetry-instrumentation-actix-web = "0.22.0"
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.36" }
 

--- a/crates/boxer-issuer-http/Cargo.toml
+++ b/crates/boxer-issuer-http/Cargo.toml
@@ -31,10 +31,10 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 # opentelemety
 
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.36" }
 opentelemetry-instrumentation-actix-web = "0.24.0"
 
 [dev-dependencies]
 rstest = "0.25.0"
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.36" }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 boxer-issuer-http = { path = "../boxer-issuer-http" }
 #boxer_core = { path = "../../../boxer-core/" }
-boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.35" }
+boxer_core = { git = "https://github.com/SneaksAndData/boxer-core.git", tag = "v0.0.36" }
 actix-web = "4.14.0"
 tokio = "1.52.3"
 anyhow = "1.0.103"


### PR DESCRIPTION
Fixes #232


## Scope

Implemented:
- Bump boxer-core to the version that makes the decision field optional and the does not create a fake `decision` field like here:
<img width="418" height="199" alt="image" src="https://github.com/user-attachments/assets/b8607bcf-4da4-4a98-92ba-b4caf7803e83" />


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.